### PR TITLE
Fix/lint rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,11 +1,2 @@
 # https://pub.dev/packages/pedantic_mono
 include: package:pedantic_mono/analysis_options.yaml
-
-analyzer:
-  exclude:
-    - lib/**/*.g.dart
-    - lib/**/*.freezed.dart
-
-linter:
-  rules:
-    

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,5 +8,4 @@ analyzer:
 
 linter:
   rules:
-    directives_ordering: false
     

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,6 +8,5 @@ analyzer:
 
 linter:
   rules:
-    sort_pub_dependencies: false
     directives_ordering: false
     

--- a/build.yaml
+++ b/build.yaml
@@ -11,3 +11,11 @@ targets:
           include:
             - lib/feature/github_repo/model/*.dart
             - lib/core/model/*.dart
+      source_gen|combining_builder:
+        options:
+          ignore_for_file:
+            - type=lint
+            - implicit_dynamic_parameter
+            - implicit_dynamic_type
+            - implicit_dynamic_method
+            - strict_raw_type

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,13 +1,8 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Packages imports:
-import 'package:hooks_riverpod/hooks_riverpod.dart';
-
-// Project imports:
 import 'package:github_repo_search/core/model/github_repos_state.dart';
 import 'package:github_repo_search/core/services/api/repo_search_client.dart';
 import 'package:github_repo_search/utils/logger.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class App extends StatelessWidget {
   const App({super.key});

--- a/lib/core/model/github_repos_state.dart
+++ b/lib/core/model/github_repos_state.dart
@@ -1,7 +1,5 @@
-// Package imports:
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-// Project imports:
 import 'package:github_repo_search/feature/github_repo/model/github_repo.dart';
 
 part 'github_repos_state.freezed.dart';

--- a/lib/core/model/github_repos_state.g.dart
+++ b/lib/core/model/github_repos_state.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
 part of 'github_repos_state.dart';
 
 // **************************************************************************

--- a/lib/core/services/api/repo_search_client.dart
+++ b/lib/core/services/api/repo_search_client.dart
@@ -1,13 +1,10 @@
-// Dart imports:
 import 'dart:convert';
 
-// Packages imports:
+import 'package:github_repo_search/utils/logger.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http/http.dart' as http;
 
-// Project imports:
 import 'api_client.dart';
-import 'package:github_repo_search/utils/logger.dart';
 
 /// HTTPクライアントプロバイダー
 final httpClientProvider = Provider<http.Client>(

--- a/lib/feature/github_repo/model/github_repo.g.dart
+++ b/lib/feature/github_repo/model/github_repo.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
 part of 'github_repo.dart';
 
 // **************************************************************************

--- a/lib/feature/github_repo/model/owner.g.dart
+++ b/lib/feature/github_repo/model/owner.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
 part of 'owner.dart';
 
 // **************************************************************************

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,8 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Packages imports:
+import 'package:github_repo_search/utils/logger.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-// Project imports:
 import 'app.dart';
-import 'package:github_repo_search/utils/logger.dart';
 
 void main() {
   Logger.configure();

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -1,4 +1,3 @@
-// Package imports:
 import 'package:simple_logger/simple_logger.dart';
 
 late SimpleLogger _logger;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,42 +8,24 @@ version: 1.0.0+1
 environment:
   sdk: ">=2.17.1 <3.0.0"
 
-
 dependencies:
   flutter:
     sdk: flutter
-
-  # Logger
+  flutter_hooks: ^0.18.5+1
+  freezed_annotation: ^2.1.0
+  hooks_riverpod: ^1.0.4
+  http: ^0.13.5
+  json_annotation: ^4.6.0
   simple_logger: ^1.9.0
 
-  # freezed
-  freezed_annotation: ^2.1.0
-  json_annotation: ^4.6.0
-
-    # API
-  http: ^0.13.5
-  
-  # Riverpod
-  hooks_riverpod: ^1.0.4
-  flutter_hooks: ^0.18.5+1
-
-
 dev_dependencies:
+  build_runner: ^2.2.0
+  flutter_lints: ^2.0.0
   flutter_test:
     sdk: flutter
-
-  # Static analysis
-  pedantic_mono: ^1.19.2
-  flutter_lints: ^2.0.0
-
-  # Serializer
-  json_serializable: ^6.3.1
-
-  # Code generator
-  build_runner: ^2.2.0
   freezed: ^2.1.0+1
-
+  json_serializable: ^6.3.1
+  pedantic_mono: ^1.19.2
 
 flutter:
-
   uses-material-design: true

--- a/test/core/model/github_repos_state_test.dart
+++ b/test/core/model/github_repos_state_test.dart
@@ -1,10 +1,6 @@
-// Dart imports:
 import 'dart:convert';
 
-// Packages imports:
 import 'package:flutter_test/flutter_test.dart';
-
-// Project imports:
 import 'package:github_repo_search/core/model/github_repos_state.dart';
 
 /// GithubReposStateクラスはその他のレスポンスクラスのルートにあたるので、


### PR DESCRIPTION
### リントルール・静的解析の修正
- `sort_pub_dependencies` `directives_ordering`のリントルールを適用外にしていたが、<br>Dart公式が推奨しており、わざわざコメントアウトせずとも可読性はそこまで落ちることはないと考え、<br>しっかり適用することにする。
- 以下の記事を参考にして、build.yamlファイルの修正と`*.g.dart`ファイルを再生成。
  - これにより、コンパイルエラーの対象に含むことが可能になった。
[Dart の JSON エンコード・デコード処理の Tips 集](https://medium.com/flutter-jp/json-60c86552fbeb)
