### PR TITLE
Feature/api error handling

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -11,6 +11,7 @@ targets:
           include:
             - lib/feature/github_repo/model/*.dart
             - lib/core/model/*.dart
+            - lib/core/services/model/**/*.dart
       source_gen|combining_builder:
         options:
           ignore_for_file:

--- a/lib/core/exceptions/api_error_response_exception.dart
+++ b/lib/core/exceptions/api_error_response_exception.dart
@@ -1,0 +1,43 @@
+import 'package:github_repo_search/core/services/model/error/client_error.dart';
+import 'package:github_repo_search/utils/logger.dart';
+
+/// ref: https://docs.github.com/ja/rest/overview/resources-in-the-rest-api#client-errors
+class ApiErrorResponseException implements Exception {
+  const ApiErrorResponseException({
+    required this.code,
+    required this.body,
+  });
+
+  final int code;
+  final ClientError body;
+
+  @override
+  String toString() {
+    logger.shout('ErrorResponseException: code=$code, body=${body.message}');
+    switch (code) {
+      case 403:
+        return 'リクエスト制限です。しばらくお待ちください。';
+
+      case 422:
+        if (body.errors == null) {
+          return '無効なフィールドです。';
+        }
+        switch (body.errors!.first.code) {
+          case 'missing':
+            return 'リソースが存在しません。';
+          case 'missing_field':
+            return '必須フィールドが設定されていません。';
+          case 'invalid':
+            return 'フィールドのフォーマットが無効です。';
+          case 'already_exists':
+            return 'リソース内容が重複しています。';
+          case 'unprocessable':
+            return '入力が無効です。';
+        }
+        return '無効なフィールドです。';
+
+      default:
+        return '再度やり直してください';
+    }
+  }
+}

--- a/lib/core/services/model/error/client_error.dart
+++ b/lib/core/services/model/error/client_error.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'error_object.dart';
+
+part 'client_error.freezed.dart';
+part 'client_error.g.dart';
+
+@freezed
+class ClientError with _$ClientError {
+  const factory ClientError({
+    required String message,
+    List<ErrorObject>? errors,
+    String? documentationUrl,
+  }) = _ClientError;
+  const ClientError._();
+
+  factory ClientError.fromJson(Map<String, dynamic> json) =>
+      _$ClientErrorFromJson(json);
+}

--- a/lib/core/services/model/error/client_error.freezed.dart
+++ b/lib/core/services/model/error/client_error.freezed.dart
@@ -1,0 +1,201 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'client_error.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ClientError _$ClientErrorFromJson(Map<String, dynamic> json) {
+  return _ClientError.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ClientError {
+  String get message => throw _privateConstructorUsedError;
+  List<ErrorObject>? get errors => throw _privateConstructorUsedError;
+  String? get documentationUrl => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ClientErrorCopyWith<ClientError> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ClientErrorCopyWith<$Res> {
+  factory $ClientErrorCopyWith(
+          ClientError value, $Res Function(ClientError) then) =
+      _$ClientErrorCopyWithImpl<$Res>;
+  $Res call(
+      {String message, List<ErrorObject>? errors, String? documentationUrl});
+}
+
+/// @nodoc
+class _$ClientErrorCopyWithImpl<$Res> implements $ClientErrorCopyWith<$Res> {
+  _$ClientErrorCopyWithImpl(this._value, this._then);
+
+  final ClientError _value;
+  // ignore: unused_field
+  final $Res Function(ClientError) _then;
+
+  @override
+  $Res call({
+    Object? message = freezed,
+    Object? errors = freezed,
+    Object? documentationUrl = freezed,
+  }) {
+    return _then(_value.copyWith(
+      message: message == freezed
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      errors: errors == freezed
+          ? _value.errors
+          : errors // ignore: cast_nullable_to_non_nullable
+              as List<ErrorObject>?,
+      documentationUrl: documentationUrl == freezed
+          ? _value.documentationUrl
+          : documentationUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_ClientErrorCopyWith<$Res>
+    implements $ClientErrorCopyWith<$Res> {
+  factory _$$_ClientErrorCopyWith(
+          _$_ClientError value, $Res Function(_$_ClientError) then) =
+      __$$_ClientErrorCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String message, List<ErrorObject>? errors, String? documentationUrl});
+}
+
+/// @nodoc
+class __$$_ClientErrorCopyWithImpl<$Res> extends _$ClientErrorCopyWithImpl<$Res>
+    implements _$$_ClientErrorCopyWith<$Res> {
+  __$$_ClientErrorCopyWithImpl(
+      _$_ClientError _value, $Res Function(_$_ClientError) _then)
+      : super(_value, (v) => _then(v as _$_ClientError));
+
+  @override
+  _$_ClientError get _value => super._value as _$_ClientError;
+
+  @override
+  $Res call({
+    Object? message = freezed,
+    Object? errors = freezed,
+    Object? documentationUrl = freezed,
+  }) {
+    return _then(_$_ClientError(
+      message: message == freezed
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      errors: errors == freezed
+          ? _value._errors
+          : errors // ignore: cast_nullable_to_non_nullable
+              as List<ErrorObject>?,
+      documentationUrl: documentationUrl == freezed
+          ? _value.documentationUrl
+          : documentationUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_ClientError extends _ClientError {
+  const _$_ClientError(
+      {required this.message,
+      final List<ErrorObject>? errors,
+      this.documentationUrl})
+      : _errors = errors,
+        super._();
+
+  factory _$_ClientError.fromJson(Map<String, dynamic> json) =>
+      _$$_ClientErrorFromJson(json);
+
+  @override
+  final String message;
+  final List<ErrorObject>? _errors;
+  @override
+  List<ErrorObject>? get errors {
+    final value = _errors;
+    if (value == null) return null;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  final String? documentationUrl;
+
+  @override
+  String toString() {
+    return 'ClientError(message: $message, errors: $errors, documentationUrl: $documentationUrl)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ClientError &&
+            const DeepCollectionEquality().equals(other.message, message) &&
+            const DeepCollectionEquality().equals(other._errors, _errors) &&
+            const DeepCollectionEquality()
+                .equals(other.documentationUrl, documentationUrl));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(message),
+      const DeepCollectionEquality().hash(_errors),
+      const DeepCollectionEquality().hash(documentationUrl));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_ClientErrorCopyWith<_$_ClientError> get copyWith =>
+      __$$_ClientErrorCopyWithImpl<_$_ClientError>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ClientErrorToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ClientError extends ClientError {
+  const factory _ClientError(
+      {required final String message,
+      final List<ErrorObject>? errors,
+      final String? documentationUrl}) = _$_ClientError;
+  const _ClientError._() : super._();
+
+  factory _ClientError.fromJson(Map<String, dynamic> json) =
+      _$_ClientError.fromJson;
+
+  @override
+  String get message;
+  @override
+  List<ErrorObject>? get errors;
+  @override
+  String? get documentationUrl;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ClientErrorCopyWith<_$_ClientError> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/core/services/model/error/client_error.g.dart
+++ b/lib/core/services/model/error/client_error.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
+part of 'client_error.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_ClientError _$$_ClientErrorFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$_ClientError',
+      json,
+      ($checkedConvert) {
+        final val = _$_ClientError(
+          message: $checkedConvert('message', (v) => v as String),
+          errors: $checkedConvert(
+              'errors',
+              (v) => (v as List<dynamic>?)
+                  ?.map((e) => ErrorObject.fromJson(e as Map<String, dynamic>))
+                  .toList()),
+          documentationUrl:
+              $checkedConvert('documentation_url', (v) => v as String?),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'documentationUrl': 'documentation_url'},
+    );
+
+Map<String, dynamic> _$$_ClientErrorToJson(_$_ClientError instance) =>
+    <String, dynamic>{
+      'message': instance.message,
+      'errors': instance.errors?.map((e) => e.toJson()).toList(),
+      'documentation_url': instance.documentationUrl,
+    };

--- a/lib/core/services/model/error/error_object.dart
+++ b/lib/core/services/model/error/error_object.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'error_object.freezed.dart';
+part 'error_object.g.dart';
+
+@freezed
+class ErrorObject with _$ErrorObject {
+  const factory ErrorObject({
+    required String resource,
+    required String field,
+    required String code,
+  }) = _ErrorObject;
+  const ErrorObject._();
+
+  factory ErrorObject.fromJson(Map<String, dynamic> json) =>
+      _$ErrorObjectFromJson(json);
+}

--- a/lib/core/services/model/error/error_object.freezed.dart
+++ b/lib/core/services/model/error/error_object.freezed.dart
@@ -1,0 +1,188 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'error_object.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ErrorObject _$ErrorObjectFromJson(Map<String, dynamic> json) {
+  return _ErrorObject.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ErrorObject {
+  String get resource => throw _privateConstructorUsedError;
+  String get field => throw _privateConstructorUsedError;
+  String get code => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ErrorObjectCopyWith<ErrorObject> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ErrorObjectCopyWith<$Res> {
+  factory $ErrorObjectCopyWith(
+          ErrorObject value, $Res Function(ErrorObject) then) =
+      _$ErrorObjectCopyWithImpl<$Res>;
+  $Res call({String resource, String field, String code});
+}
+
+/// @nodoc
+class _$ErrorObjectCopyWithImpl<$Res> implements $ErrorObjectCopyWith<$Res> {
+  _$ErrorObjectCopyWithImpl(this._value, this._then);
+
+  final ErrorObject _value;
+  // ignore: unused_field
+  final $Res Function(ErrorObject) _then;
+
+  @override
+  $Res call({
+    Object? resource = freezed,
+    Object? field = freezed,
+    Object? code = freezed,
+  }) {
+    return _then(_value.copyWith(
+      resource: resource == freezed
+          ? _value.resource
+          : resource // ignore: cast_nullable_to_non_nullable
+              as String,
+      field: field == freezed
+          ? _value.field
+          : field // ignore: cast_nullable_to_non_nullable
+              as String,
+      code: code == freezed
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_ErrorObjectCopyWith<$Res>
+    implements $ErrorObjectCopyWith<$Res> {
+  factory _$$_ErrorObjectCopyWith(
+          _$_ErrorObject value, $Res Function(_$_ErrorObject) then) =
+      __$$_ErrorObjectCopyWithImpl<$Res>;
+  @override
+  $Res call({String resource, String field, String code});
+}
+
+/// @nodoc
+class __$$_ErrorObjectCopyWithImpl<$Res> extends _$ErrorObjectCopyWithImpl<$Res>
+    implements _$$_ErrorObjectCopyWith<$Res> {
+  __$$_ErrorObjectCopyWithImpl(
+      _$_ErrorObject _value, $Res Function(_$_ErrorObject) _then)
+      : super(_value, (v) => _then(v as _$_ErrorObject));
+
+  @override
+  _$_ErrorObject get _value => super._value as _$_ErrorObject;
+
+  @override
+  $Res call({
+    Object? resource = freezed,
+    Object? field = freezed,
+    Object? code = freezed,
+  }) {
+    return _then(_$_ErrorObject(
+      resource: resource == freezed
+          ? _value.resource
+          : resource // ignore: cast_nullable_to_non_nullable
+              as String,
+      field: field == freezed
+          ? _value.field
+          : field // ignore: cast_nullable_to_non_nullable
+              as String,
+      code: code == freezed
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_ErrorObject extends _ErrorObject {
+  const _$_ErrorObject(
+      {required this.resource, required this.field, required this.code})
+      : super._();
+
+  factory _$_ErrorObject.fromJson(Map<String, dynamic> json) =>
+      _$$_ErrorObjectFromJson(json);
+
+  @override
+  final String resource;
+  @override
+  final String field;
+  @override
+  final String code;
+
+  @override
+  String toString() {
+    return 'ErrorObject(resource: $resource, field: $field, code: $code)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ErrorObject &&
+            const DeepCollectionEquality().equals(other.resource, resource) &&
+            const DeepCollectionEquality().equals(other.field, field) &&
+            const DeepCollectionEquality().equals(other.code, code));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(resource),
+      const DeepCollectionEquality().hash(field),
+      const DeepCollectionEquality().hash(code));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_ErrorObjectCopyWith<_$_ErrorObject> get copyWith =>
+      __$$_ErrorObjectCopyWithImpl<_$_ErrorObject>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ErrorObjectToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ErrorObject extends ErrorObject {
+  const factory _ErrorObject(
+      {required final String resource,
+      required final String field,
+      required final String code}) = _$_ErrorObject;
+  const _ErrorObject._() : super._();
+
+  factory _ErrorObject.fromJson(Map<String, dynamic> json) =
+      _$_ErrorObject.fromJson;
+
+  @override
+  String get resource;
+  @override
+  String get field;
+  @override
+  String get code;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ErrorObjectCopyWith<_$_ErrorObject> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/core/services/model/error/error_object.g.dart
+++ b/lib/core/services/model/error/error_object.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
+part of 'error_object.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_ErrorObject _$$_ErrorObjectFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$_ErrorObject',
+      json,
+      ($checkedConvert) {
+        final val = _$_ErrorObject(
+          resource: $checkedConvert('resource', (v) => v as String),
+          field: $checkedConvert('field', (v) => v as String),
+          code: $checkedConvert('code', (v) => v as String),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$_ErrorObjectToJson(_$_ErrorObject instance) =>
+    <String, dynamic>{
+      'resource': instance.resource,
+      'field': instance.field,
+      'code': instance.code,
+    };


### PR DESCRIPTION
### APIエラーハンドリング機能を追加
- [search API クライアントエラー](https://docs.github.com/ja/rest/overview/resources-in-the-rest-api#client-errors)を参考にエラーレスポンスモデル(`ClientError`)を作成。
- エラーレスポンスだった場合にClientErrorモデルでデコードするために、try-catch構文をやめてエラーをthrowする。
  - StateNotifierクラスでリポジトリを管理しようと思っているので、そこのgetメソッド内のtry-catch構文でエラーをcatchする。
- Exceptionをimplementsし、ステータスコードに応じたエラー文を返すクラス(`ApiErrorResponseException`)を作成。