### PR TITLE
Feature/pagination of git hub repositories

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -12,6 +12,8 @@ targets:
             - lib/feature/github_repo/model/*.dart
             - lib/core/model/*.dart
             - lib/core/services/model/**/*.dart
+            - lib/core/services/model/*.dart
+
       source_gen|combining_builder:
         options:
           ignore_for_file:

--- a/build.yaml
+++ b/build.yaml
@@ -10,6 +10,7 @@ targets:
         generate_for:
           include:
             - lib/feature/github_repo/model/*.dart
+            - lib/feature/github_repo/pagination/model/*.dart
             - lib/core/model/*.dart
             - lib/core/services/model/**/*.dart
             - lib/core/services/model/*.dart

--- a/lib/core/model/pagination_state.dart
+++ b/lib/core/model/pagination_state.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pagination_state.freezed.dart';
+
+@freezed
+class PaginationState<T> with _$PaginationState<T> {
+  const factory PaginationState.data(T data) = _Data;
+  const factory PaginationState.loading() = _Loading;
+  const factory PaginationState.error(Object? e, [StackTrace? stk]) = _Error;
+  const factory PaginationState.onGoingLoading(T previousData) =
+      _OnGoingLoading;
+  const factory PaginationState.onGoingError(
+    T previousData,
+    Object? e, [
+    StackTrace? stk,
+  ]) = _OnGoingError;
+}

--- a/lib/core/model/pagination_state.freezed.dart
+++ b/lib/core/model/pagination_state.freezed.dart
@@ -1,0 +1,856 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'pagination_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$PaginationState<T> {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) data,
+    required TResult Function() loading,
+    required TResult Function(Object? e, StackTrace? stk) error,
+    required TResult Function(T previousData) onGoingLoading,
+    required TResult Function(T previousData, Object? e, StackTrace? stk)
+        onGoingError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Data<T> value) data,
+    required TResult Function(_Loading<T> value) loading,
+    required TResult Function(_Error<T> value) error,
+    required TResult Function(_OnGoingLoading<T> value) onGoingLoading,
+    required TResult Function(_OnGoingError<T> value) onGoingError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PaginationStateCopyWith<T, $Res> {
+  factory $PaginationStateCopyWith(
+          PaginationState<T> value, $Res Function(PaginationState<T>) then) =
+      _$PaginationStateCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class _$PaginationStateCopyWithImpl<T, $Res>
+    implements $PaginationStateCopyWith<T, $Res> {
+  _$PaginationStateCopyWithImpl(this._value, this._then);
+
+  final PaginationState<T> _value;
+  // ignore: unused_field
+  final $Res Function(PaginationState<T>) _then;
+}
+
+/// @nodoc
+abstract class _$$_DataCopyWith<T, $Res> {
+  factory _$$_DataCopyWith(_$_Data<T> value, $Res Function(_$_Data<T>) then) =
+      __$$_DataCopyWithImpl<T, $Res>;
+  $Res call({T data});
+}
+
+/// @nodoc
+class __$$_DataCopyWithImpl<T, $Res>
+    extends _$PaginationStateCopyWithImpl<T, $Res>
+    implements _$$_DataCopyWith<T, $Res> {
+  __$$_DataCopyWithImpl(_$_Data<T> _value, $Res Function(_$_Data<T>) _then)
+      : super(_value, (v) => _then(v as _$_Data<T>));
+
+  @override
+  _$_Data<T> get _value => super._value as _$_Data<T>;
+
+  @override
+  $Res call({
+    Object? data = freezed,
+  }) {
+    return _then(_$_Data<T>(
+      data == freezed
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as T,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Data<T> implements _Data<T> {
+  const _$_Data(this.data);
+
+  @override
+  final T data;
+
+  @override
+  String toString() {
+    return 'PaginationState<$T>.data(data: $data)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Data<T> &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(data));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_DataCopyWith<T, _$_Data<T>> get copyWith =>
+      __$$_DataCopyWithImpl<T, _$_Data<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) data,
+    required TResult Function() loading,
+    required TResult Function(Object? e, StackTrace? stk) error,
+    required TResult Function(T previousData) onGoingLoading,
+    required TResult Function(T previousData, Object? e, StackTrace? stk)
+        onGoingError,
+  }) {
+    return data(this.data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+  }) {
+    return data?.call(this.data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (data != null) {
+      return data(this.data);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Data<T> value) data,
+    required TResult Function(_Loading<T> value) loading,
+    required TResult Function(_Error<T> value) error,
+    required TResult Function(_OnGoingLoading<T> value) onGoingLoading,
+    required TResult Function(_OnGoingError<T> value) onGoingError,
+  }) {
+    return data(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+  }) {
+    return data?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (data != null) {
+      return data(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Data<T> implements PaginationState<T> {
+  const factory _Data(final T data) = _$_Data<T>;
+
+  T get data;
+  @JsonKey(ignore: true)
+  _$$_DataCopyWith<T, _$_Data<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$_LoadingCopyWith<T, $Res> {
+  factory _$$_LoadingCopyWith(
+          _$_Loading<T> value, $Res Function(_$_Loading<T>) then) =
+      __$$_LoadingCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class __$$_LoadingCopyWithImpl<T, $Res>
+    extends _$PaginationStateCopyWithImpl<T, $Res>
+    implements _$$_LoadingCopyWith<T, $Res> {
+  __$$_LoadingCopyWithImpl(
+      _$_Loading<T> _value, $Res Function(_$_Loading<T>) _then)
+      : super(_value, (v) => _then(v as _$_Loading<T>));
+
+  @override
+  _$_Loading<T> get _value => super._value as _$_Loading<T>;
+}
+
+/// @nodoc
+
+class _$_Loading<T> implements _Loading<T> {
+  const _$_Loading();
+
+  @override
+  String toString() {
+    return 'PaginationState<$T>.loading()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$_Loading<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) data,
+    required TResult Function() loading,
+    required TResult Function(Object? e, StackTrace? stk) error,
+    required TResult Function(T previousData) onGoingLoading,
+    required TResult Function(T previousData, Object? e, StackTrace? stk)
+        onGoingError,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Data<T> value) data,
+    required TResult Function(_Loading<T> value) loading,
+    required TResult Function(_Error<T> value) error,
+    required TResult Function(_OnGoingLoading<T> value) onGoingLoading,
+    required TResult Function(_OnGoingError<T> value) onGoingError,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Loading<T> implements PaginationState<T> {
+  const factory _Loading() = _$_Loading<T>;
+}
+
+/// @nodoc
+abstract class _$$_ErrorCopyWith<T, $Res> {
+  factory _$$_ErrorCopyWith(
+          _$_Error<T> value, $Res Function(_$_Error<T>) then) =
+      __$$_ErrorCopyWithImpl<T, $Res>;
+  $Res call({Object? e, StackTrace? stk});
+}
+
+/// @nodoc
+class __$$_ErrorCopyWithImpl<T, $Res>
+    extends _$PaginationStateCopyWithImpl<T, $Res>
+    implements _$$_ErrorCopyWith<T, $Res> {
+  __$$_ErrorCopyWithImpl(_$_Error<T> _value, $Res Function(_$_Error<T>) _then)
+      : super(_value, (v) => _then(v as _$_Error<T>));
+
+  @override
+  _$_Error<T> get _value => super._value as _$_Error<T>;
+
+  @override
+  $Res call({
+    Object? e = freezed,
+    Object? stk = freezed,
+  }) {
+    return _then(_$_Error<T>(
+      e == freezed ? _value.e : e,
+      stk == freezed
+          ? _value.stk
+          : stk // ignore: cast_nullable_to_non_nullable
+              as StackTrace?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Error<T> implements _Error<T> {
+  const _$_Error(this.e, [this.stk]);
+
+  @override
+  final Object? e;
+  @override
+  final StackTrace? stk;
+
+  @override
+  String toString() {
+    return 'PaginationState<$T>.error(e: $e, stk: $stk)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Error<T> &&
+            const DeepCollectionEquality().equals(other.e, e) &&
+            const DeepCollectionEquality().equals(other.stk, stk));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(e),
+      const DeepCollectionEquality().hash(stk));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_ErrorCopyWith<T, _$_Error<T>> get copyWith =>
+      __$$_ErrorCopyWithImpl<T, _$_Error<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) data,
+    required TResult Function() loading,
+    required TResult Function(Object? e, StackTrace? stk) error,
+    required TResult Function(T previousData) onGoingLoading,
+    required TResult Function(T previousData, Object? e, StackTrace? stk)
+        onGoingError,
+  }) {
+    return error(e, stk);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+  }) {
+    return error?.call(e, stk);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(e, stk);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Data<T> value) data,
+    required TResult Function(_Loading<T> value) loading,
+    required TResult Function(_Error<T> value) error,
+    required TResult Function(_OnGoingLoading<T> value) onGoingLoading,
+    required TResult Function(_OnGoingError<T> value) onGoingError,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Error<T> implements PaginationState<T> {
+  const factory _Error(final Object? e, [final StackTrace? stk]) = _$_Error<T>;
+
+  Object? get e;
+  StackTrace? get stk;
+  @JsonKey(ignore: true)
+  _$$_ErrorCopyWith<T, _$_Error<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$_OnGoingLoadingCopyWith<T, $Res> {
+  factory _$$_OnGoingLoadingCopyWith(_$_OnGoingLoading<T> value,
+          $Res Function(_$_OnGoingLoading<T>) then) =
+      __$$_OnGoingLoadingCopyWithImpl<T, $Res>;
+  $Res call({T previousData});
+}
+
+/// @nodoc
+class __$$_OnGoingLoadingCopyWithImpl<T, $Res>
+    extends _$PaginationStateCopyWithImpl<T, $Res>
+    implements _$$_OnGoingLoadingCopyWith<T, $Res> {
+  __$$_OnGoingLoadingCopyWithImpl(
+      _$_OnGoingLoading<T> _value, $Res Function(_$_OnGoingLoading<T>) _then)
+      : super(_value, (v) => _then(v as _$_OnGoingLoading<T>));
+
+  @override
+  _$_OnGoingLoading<T> get _value => super._value as _$_OnGoingLoading<T>;
+
+  @override
+  $Res call({
+    Object? previousData = freezed,
+  }) {
+    return _then(_$_OnGoingLoading<T>(
+      previousData == freezed
+          ? _value.previousData
+          : previousData // ignore: cast_nullable_to_non_nullable
+              as T,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_OnGoingLoading<T> implements _OnGoingLoading<T> {
+  const _$_OnGoingLoading(this.previousData);
+
+  @override
+  final T previousData;
+
+  @override
+  String toString() {
+    return 'PaginationState<$T>.onGoingLoading(previousData: $previousData)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_OnGoingLoading<T> &&
+            const DeepCollectionEquality()
+                .equals(other.previousData, previousData));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(previousData));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_OnGoingLoadingCopyWith<T, _$_OnGoingLoading<T>> get copyWith =>
+      __$$_OnGoingLoadingCopyWithImpl<T, _$_OnGoingLoading<T>>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) data,
+    required TResult Function() loading,
+    required TResult Function(Object? e, StackTrace? stk) error,
+    required TResult Function(T previousData) onGoingLoading,
+    required TResult Function(T previousData, Object? e, StackTrace? stk)
+        onGoingError,
+  }) {
+    return onGoingLoading(previousData);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+  }) {
+    return onGoingLoading?.call(previousData);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (onGoingLoading != null) {
+      return onGoingLoading(previousData);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Data<T> value) data,
+    required TResult Function(_Loading<T> value) loading,
+    required TResult Function(_Error<T> value) error,
+    required TResult Function(_OnGoingLoading<T> value) onGoingLoading,
+    required TResult Function(_OnGoingError<T> value) onGoingError,
+  }) {
+    return onGoingLoading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+  }) {
+    return onGoingLoading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (onGoingLoading != null) {
+      return onGoingLoading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _OnGoingLoading<T> implements PaginationState<T> {
+  const factory _OnGoingLoading(final T previousData) = _$_OnGoingLoading<T>;
+
+  T get previousData;
+  @JsonKey(ignore: true)
+  _$$_OnGoingLoadingCopyWith<T, _$_OnGoingLoading<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$_OnGoingErrorCopyWith<T, $Res> {
+  factory _$$_OnGoingErrorCopyWith(
+          _$_OnGoingError<T> value, $Res Function(_$_OnGoingError<T>) then) =
+      __$$_OnGoingErrorCopyWithImpl<T, $Res>;
+  $Res call({T previousData, Object? e, StackTrace? stk});
+}
+
+/// @nodoc
+class __$$_OnGoingErrorCopyWithImpl<T, $Res>
+    extends _$PaginationStateCopyWithImpl<T, $Res>
+    implements _$$_OnGoingErrorCopyWith<T, $Res> {
+  __$$_OnGoingErrorCopyWithImpl(
+      _$_OnGoingError<T> _value, $Res Function(_$_OnGoingError<T>) _then)
+      : super(_value, (v) => _then(v as _$_OnGoingError<T>));
+
+  @override
+  _$_OnGoingError<T> get _value => super._value as _$_OnGoingError<T>;
+
+  @override
+  $Res call({
+    Object? previousData = freezed,
+    Object? e = freezed,
+    Object? stk = freezed,
+  }) {
+    return _then(_$_OnGoingError<T>(
+      previousData == freezed
+          ? _value.previousData
+          : previousData // ignore: cast_nullable_to_non_nullable
+              as T,
+      e == freezed ? _value.e : e,
+      stk == freezed
+          ? _value.stk
+          : stk // ignore: cast_nullable_to_non_nullable
+              as StackTrace?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_OnGoingError<T> implements _OnGoingError<T> {
+  const _$_OnGoingError(this.previousData, this.e, [this.stk]);
+
+  @override
+  final T previousData;
+  @override
+  final Object? e;
+  @override
+  final StackTrace? stk;
+
+  @override
+  String toString() {
+    return 'PaginationState<$T>.onGoingError(previousData: $previousData, e: $e, stk: $stk)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_OnGoingError<T> &&
+            const DeepCollectionEquality()
+                .equals(other.previousData, previousData) &&
+            const DeepCollectionEquality().equals(other.e, e) &&
+            const DeepCollectionEquality().equals(other.stk, stk));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(previousData),
+      const DeepCollectionEquality().hash(e),
+      const DeepCollectionEquality().hash(stk));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_OnGoingErrorCopyWith<T, _$_OnGoingError<T>> get copyWith =>
+      __$$_OnGoingErrorCopyWithImpl<T, _$_OnGoingError<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) data,
+    required TResult Function() loading,
+    required TResult Function(Object? e, StackTrace? stk) error,
+    required TResult Function(T previousData) onGoingLoading,
+    required TResult Function(T previousData, Object? e, StackTrace? stk)
+        onGoingError,
+  }) {
+    return onGoingError(previousData, e, stk);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+  }) {
+    return onGoingError?.call(previousData, e, stk);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? data,
+    TResult Function()? loading,
+    TResult Function(Object? e, StackTrace? stk)? error,
+    TResult Function(T previousData)? onGoingLoading,
+    TResult Function(T previousData, Object? e, StackTrace? stk)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (onGoingError != null) {
+      return onGoingError(previousData, e, stk);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Data<T> value) data,
+    required TResult Function(_Loading<T> value) loading,
+    required TResult Function(_Error<T> value) error,
+    required TResult Function(_OnGoingLoading<T> value) onGoingLoading,
+    required TResult Function(_OnGoingError<T> value) onGoingError,
+  }) {
+    return onGoingError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+  }) {
+    return onGoingError?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Data<T> value)? data,
+    TResult Function(_Loading<T> value)? loading,
+    TResult Function(_Error<T> value)? error,
+    TResult Function(_OnGoingLoading<T> value)? onGoingLoading,
+    TResult Function(_OnGoingError<T> value)? onGoingError,
+    required TResult orElse(),
+  }) {
+    if (onGoingError != null) {
+      return onGoingError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _OnGoingError<T> implements PaginationState<T> {
+  const factory _OnGoingError(final T previousData, final Object? e,
+      [final StackTrace? stk]) = _$_OnGoingError<T>;
+
+  T get previousData;
+  Object? get e;
+  StackTrace? get stk;
+  @JsonKey(ignore: true)
+  _$$_OnGoingErrorCopyWith<T, _$_OnGoingError<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/core/services/model/int_and_string_converter.dart
+++ b/lib/core/services/model/int_and_string_converter.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+class IntAndStringConverter implements JsonConverter<int, String> {
+  const IntAndStringConverter();
+
+  @override
+  int fromJson(String value) => int.parse(value);
+
+  @override
+  String toJson(int value) {
+    return value.toString();
+  }
+}

--- a/lib/core/services/model/repo_search_request_param.dart
+++ b/lib/core/services/model/repo_search_request_param.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:github_repo_search/core/services/model/int_and_string_converter.dart';
+
+part 'repo_search_request_param.freezed.dart';
+part 'repo_search_request_param.g.dart';
+
+@freezed
+class RepoSearchRequestParam with _$RepoSearchRequestParam {
+  const factory RepoSearchRequestParam({
+    required String q,
+    String? sort,
+    String? order,
+    @IntAndStringConverter() @Default(30) int perPage,
+    @IntAndStringConverter() @Default(1) int page,
+  }) = _RepoSearchRequestParam;
+
+  factory RepoSearchRequestParam.fromJson(Map<String, dynamic> json) =>
+      _$RepoSearchRequestParamFromJson(json);
+}

--- a/lib/core/services/model/repo_search_request_param.freezed.dart
+++ b/lib/core/services/model/repo_search_request_param.freezed.dart
@@ -1,0 +1,249 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'repo_search_request_param.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+RepoSearchRequestParam _$RepoSearchRequestParamFromJson(
+    Map<String, dynamic> json) {
+  return _RepoSearchRequestParam.fromJson(json);
+}
+
+/// @nodoc
+mixin _$RepoSearchRequestParam {
+  String get q => throw _privateConstructorUsedError;
+  String? get sort => throw _privateConstructorUsedError;
+  String? get order => throw _privateConstructorUsedError;
+  @IntAndStringConverter()
+  int get perPage => throw _privateConstructorUsedError;
+  @IntAndStringConverter()
+  int get page => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $RepoSearchRequestParamCopyWith<RepoSearchRequestParam> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RepoSearchRequestParamCopyWith<$Res> {
+  factory $RepoSearchRequestParamCopyWith(RepoSearchRequestParam value,
+          $Res Function(RepoSearchRequestParam) then) =
+      _$RepoSearchRequestParamCopyWithImpl<$Res>;
+  $Res call(
+      {String q,
+      String? sort,
+      String? order,
+      @IntAndStringConverter() int perPage,
+      @IntAndStringConverter() int page});
+}
+
+/// @nodoc
+class _$RepoSearchRequestParamCopyWithImpl<$Res>
+    implements $RepoSearchRequestParamCopyWith<$Res> {
+  _$RepoSearchRequestParamCopyWithImpl(this._value, this._then);
+
+  final RepoSearchRequestParam _value;
+  // ignore: unused_field
+  final $Res Function(RepoSearchRequestParam) _then;
+
+  @override
+  $Res call({
+    Object? q = freezed,
+    Object? sort = freezed,
+    Object? order = freezed,
+    Object? perPage = freezed,
+    Object? page = freezed,
+  }) {
+    return _then(_value.copyWith(
+      q: q == freezed
+          ? _value.q
+          : q // ignore: cast_nullable_to_non_nullable
+              as String,
+      sort: sort == freezed
+          ? _value.sort
+          : sort // ignore: cast_nullable_to_non_nullable
+              as String?,
+      order: order == freezed
+          ? _value.order
+          : order // ignore: cast_nullable_to_non_nullable
+              as String?,
+      perPage: perPage == freezed
+          ? _value.perPage
+          : perPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      page: page == freezed
+          ? _value.page
+          : page // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_RepoSearchRequestParamCopyWith<$Res>
+    implements $RepoSearchRequestParamCopyWith<$Res> {
+  factory _$$_RepoSearchRequestParamCopyWith(_$_RepoSearchRequestParam value,
+          $Res Function(_$_RepoSearchRequestParam) then) =
+      __$$_RepoSearchRequestParamCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String q,
+      String? sort,
+      String? order,
+      @IntAndStringConverter() int perPage,
+      @IntAndStringConverter() int page});
+}
+
+/// @nodoc
+class __$$_RepoSearchRequestParamCopyWithImpl<$Res>
+    extends _$RepoSearchRequestParamCopyWithImpl<$Res>
+    implements _$$_RepoSearchRequestParamCopyWith<$Res> {
+  __$$_RepoSearchRequestParamCopyWithImpl(_$_RepoSearchRequestParam _value,
+      $Res Function(_$_RepoSearchRequestParam) _then)
+      : super(_value, (v) => _then(v as _$_RepoSearchRequestParam));
+
+  @override
+  _$_RepoSearchRequestParam get _value =>
+      super._value as _$_RepoSearchRequestParam;
+
+  @override
+  $Res call({
+    Object? q = freezed,
+    Object? sort = freezed,
+    Object? order = freezed,
+    Object? perPage = freezed,
+    Object? page = freezed,
+  }) {
+    return _then(_$_RepoSearchRequestParam(
+      q: q == freezed
+          ? _value.q
+          : q // ignore: cast_nullable_to_non_nullable
+              as String,
+      sort: sort == freezed
+          ? _value.sort
+          : sort // ignore: cast_nullable_to_non_nullable
+              as String?,
+      order: order == freezed
+          ? _value.order
+          : order // ignore: cast_nullable_to_non_nullable
+              as String?,
+      perPage: perPage == freezed
+          ? _value.perPage
+          : perPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      page: page == freezed
+          ? _value.page
+          : page // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_RepoSearchRequestParam implements _RepoSearchRequestParam {
+  const _$_RepoSearchRequestParam(
+      {required this.q,
+      this.sort,
+      this.order,
+      @IntAndStringConverter() this.perPage = 30,
+      @IntAndStringConverter() this.page = 1});
+
+  factory _$_RepoSearchRequestParam.fromJson(Map<String, dynamic> json) =>
+      _$$_RepoSearchRequestParamFromJson(json);
+
+  @override
+  final String q;
+  @override
+  final String? sort;
+  @override
+  final String? order;
+  @override
+  @JsonKey()
+  @IntAndStringConverter()
+  final int perPage;
+  @override
+  @JsonKey()
+  @IntAndStringConverter()
+  final int page;
+
+  @override
+  String toString() {
+    return 'RepoSearchRequestParam(q: $q, sort: $sort, order: $order, perPage: $perPage, page: $page)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_RepoSearchRequestParam &&
+            const DeepCollectionEquality().equals(other.q, q) &&
+            const DeepCollectionEquality().equals(other.sort, sort) &&
+            const DeepCollectionEquality().equals(other.order, order) &&
+            const DeepCollectionEquality().equals(other.perPage, perPage) &&
+            const DeepCollectionEquality().equals(other.page, page));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(q),
+      const DeepCollectionEquality().hash(sort),
+      const DeepCollectionEquality().hash(order),
+      const DeepCollectionEquality().hash(perPage),
+      const DeepCollectionEquality().hash(page));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_RepoSearchRequestParamCopyWith<_$_RepoSearchRequestParam> get copyWith =>
+      __$$_RepoSearchRequestParamCopyWithImpl<_$_RepoSearchRequestParam>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_RepoSearchRequestParamToJson(
+      this,
+    );
+  }
+}
+
+abstract class _RepoSearchRequestParam implements RepoSearchRequestParam {
+  const factory _RepoSearchRequestParam(
+      {required final String q,
+      final String? sort,
+      final String? order,
+      @IntAndStringConverter() final int perPage,
+      @IntAndStringConverter() final int page}) = _$_RepoSearchRequestParam;
+
+  factory _RepoSearchRequestParam.fromJson(Map<String, dynamic> json) =
+      _$_RepoSearchRequestParam.fromJson;
+
+  @override
+  String get q;
+  @override
+  String? get sort;
+  @override
+  String? get order;
+  @override
+  @IntAndStringConverter()
+  int get perPage;
+  @override
+  @IntAndStringConverter()
+  int get page;
+  @override
+  @JsonKey(ignore: true)
+  _$$_RepoSearchRequestParamCopyWith<_$_RepoSearchRequestParam> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/core/services/model/repo_search_request_param.g.dart
+++ b/lib/core/services/model/repo_search_request_param.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
+part of 'repo_search_request_param.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_RepoSearchRequestParam _$$_RepoSearchRequestParamFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$_RepoSearchRequestParam',
+      json,
+      ($checkedConvert) {
+        final val = _$_RepoSearchRequestParam(
+          q: $checkedConvert('q', (v) => v as String),
+          sort: $checkedConvert('sort', (v) => v as String?),
+          order: $checkedConvert('order', (v) => v as String?),
+          perPage: $checkedConvert(
+              'per_page',
+              (v) => v == null
+                  ? 30
+                  : const IntAndStringConverter().fromJson(v as String)),
+          page: $checkedConvert(
+              'page',
+              (v) => v == null
+                  ? 1
+                  : const IntAndStringConverter().fromJson(v as String)),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'perPage': 'per_page'},
+    );
+
+Map<String, dynamic> _$$_RepoSearchRequestParamToJson(
+        _$_RepoSearchRequestParam instance) =>
+    <String, dynamic>{
+      'q': instance.q,
+      'sort': instance.sort,
+      'order': instance.order,
+      'per_page': const IntAndStringConverter().toJson(instance.perPage),
+      'page': const IntAndStringConverter().toJson(instance.page),
+    };

--- a/lib/core/widgets/retry_button.dart
+++ b/lib/core/widgets/retry_button.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+
+class RetryButton extends StatelessWidget {
+  const RetryButton({
+    super.key,
+    required this.title,
+    required this.textButton,
+  });
+
+  final String title;
+  final ButtonStyleButton textButton;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(title),
+          const Gap(20),
+          textButton,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/smart_refresher_custom.dart
+++ b/lib/core/widgets/smart_refresher_custom.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:pull_to_refresh_flutter3/pull_to_refresh_flutter3.dart';
+
+class SmartRefreshHeader extends StatelessWidget {
+  const SmartRefreshHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomHeader(
+      builder: (context, mode) {
+        if (mode == RefreshStatus.idle) {
+          return const SizedBox.shrink();
+        }
+        return const SizedBox(
+          height: 55,
+          child: Center(child: CircularProgressIndicator()),
+        );
+      },
+    );
+  }
+}
+
+class SmartRefreshFooter extends StatelessWidget {
+  const SmartRefreshFooter({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomFooter(
+      builder: (context, mode) {
+        return SizedBox(
+          height: 55,
+          child: mode == LoadStatus.idle
+              ? const SizedBox.shrink()
+              : const Center(child: CircularProgressIndicator()),
+        );
+      },
+    );
+  }
+}

--- a/lib/feature/github_repo/pagination/model/repo_pagination_state.dart
+++ b/lib/feature/github_repo/pagination/model/repo_pagination_state.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:github_repo_search/core/model/github_repos_state.dart';
+import 'package:github_repo_search/core/services/model/repo_search_request_param.dart';
+import 'package:github_repo_search/feature/github_repo/model/github_repo.dart';
+
+part 'repo_pagination_state.freezed.dart';
+
+@freezed
+class RepoPaginationState with _$RepoPaginationState {
+  const factory RepoPaginationState({
+    @Default(0) int totalCount,
+    @Default(<GithubRepo>[]) List<GithubRepo> items,
+    required RepoSearchRequestParam param,
+  }) = _RepoPaginationState;
+
+  factory RepoPaginationState.update(
+    GithubReposState githubReposState,
+    RepoSearchRequestParam param,
+  ) {
+    return RepoPaginationState(
+      totalCount: githubReposState.totalCount,
+      items: githubReposState.items,
+      param: param,
+    );
+  }
+}

--- a/lib/feature/github_repo/pagination/model/repo_pagination_state.freezed.dart
+++ b/lib/feature/github_repo/pagination/model/repo_pagination_state.freezed.dart
@@ -1,0 +1,195 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'repo_pagination_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$RepoPaginationState {
+  int get totalCount => throw _privateConstructorUsedError;
+  List<GithubRepo> get items => throw _privateConstructorUsedError;
+  RepoSearchRequestParam get param => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $RepoPaginationStateCopyWith<RepoPaginationState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RepoPaginationStateCopyWith<$Res> {
+  factory $RepoPaginationStateCopyWith(
+          RepoPaginationState value, $Res Function(RepoPaginationState) then) =
+      _$RepoPaginationStateCopyWithImpl<$Res>;
+  $Res call(
+      {int totalCount, List<GithubRepo> items, RepoSearchRequestParam param});
+
+  $RepoSearchRequestParamCopyWith<$Res> get param;
+}
+
+/// @nodoc
+class _$RepoPaginationStateCopyWithImpl<$Res>
+    implements $RepoPaginationStateCopyWith<$Res> {
+  _$RepoPaginationStateCopyWithImpl(this._value, this._then);
+
+  final RepoPaginationState _value;
+  // ignore: unused_field
+  final $Res Function(RepoPaginationState) _then;
+
+  @override
+  $Res call({
+    Object? totalCount = freezed,
+    Object? items = freezed,
+    Object? param = freezed,
+  }) {
+    return _then(_value.copyWith(
+      totalCount: totalCount == freezed
+          ? _value.totalCount
+          : totalCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      items: items == freezed
+          ? _value.items
+          : items // ignore: cast_nullable_to_non_nullable
+              as List<GithubRepo>,
+      param: param == freezed
+          ? _value.param
+          : param // ignore: cast_nullable_to_non_nullable
+              as RepoSearchRequestParam,
+    ));
+  }
+
+  @override
+  $RepoSearchRequestParamCopyWith<$Res> get param {
+    return $RepoSearchRequestParamCopyWith<$Res>(_value.param, (value) {
+      return _then(_value.copyWith(param: value));
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$_RepoPaginationStateCopyWith<$Res>
+    implements $RepoPaginationStateCopyWith<$Res> {
+  factory _$$_RepoPaginationStateCopyWith(_$_RepoPaginationState value,
+          $Res Function(_$_RepoPaginationState) then) =
+      __$$_RepoPaginationStateCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {int totalCount, List<GithubRepo> items, RepoSearchRequestParam param});
+
+  @override
+  $RepoSearchRequestParamCopyWith<$Res> get param;
+}
+
+/// @nodoc
+class __$$_RepoPaginationStateCopyWithImpl<$Res>
+    extends _$RepoPaginationStateCopyWithImpl<$Res>
+    implements _$$_RepoPaginationStateCopyWith<$Res> {
+  __$$_RepoPaginationStateCopyWithImpl(_$_RepoPaginationState _value,
+      $Res Function(_$_RepoPaginationState) _then)
+      : super(_value, (v) => _then(v as _$_RepoPaginationState));
+
+  @override
+  _$_RepoPaginationState get _value => super._value as _$_RepoPaginationState;
+
+  @override
+  $Res call({
+    Object? totalCount = freezed,
+    Object? items = freezed,
+    Object? param = freezed,
+  }) {
+    return _then(_$_RepoPaginationState(
+      totalCount: totalCount == freezed
+          ? _value.totalCount
+          : totalCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      items: items == freezed
+          ? _value._items
+          : items // ignore: cast_nullable_to_non_nullable
+              as List<GithubRepo>,
+      param: param == freezed
+          ? _value.param
+          : param // ignore: cast_nullable_to_non_nullable
+              as RepoSearchRequestParam,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_RepoPaginationState implements _RepoPaginationState {
+  const _$_RepoPaginationState(
+      {this.totalCount = 0,
+      final List<GithubRepo> items = const <GithubRepo>[],
+      required this.param})
+      : _items = items;
+
+  @override
+  @JsonKey()
+  final int totalCount;
+  final List<GithubRepo> _items;
+  @override
+  @JsonKey()
+  List<GithubRepo> get items {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_items);
+  }
+
+  @override
+  final RepoSearchRequestParam param;
+
+  @override
+  String toString() {
+    return 'RepoPaginationState(totalCount: $totalCount, items: $items, param: $param)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_RepoPaginationState &&
+            const DeepCollectionEquality()
+                .equals(other.totalCount, totalCount) &&
+            const DeepCollectionEquality().equals(other._items, _items) &&
+            const DeepCollectionEquality().equals(other.param, param));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(totalCount),
+      const DeepCollectionEquality().hash(_items),
+      const DeepCollectionEquality().hash(param));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_RepoPaginationStateCopyWith<_$_RepoPaginationState> get copyWith =>
+      __$$_RepoPaginationStateCopyWithImpl<_$_RepoPaginationState>(
+          this, _$identity);
+}
+
+abstract class _RepoPaginationState implements RepoPaginationState {
+  const factory _RepoPaginationState(
+      {final int totalCount,
+      final List<GithubRepo> items,
+      required final RepoSearchRequestParam param}) = _$_RepoPaginationState;
+
+  @override
+  int get totalCount;
+  @override
+  List<GithubRepo> get items;
+  @override
+  RepoSearchRequestParam get param;
+  @override
+  @JsonKey(ignore: true)
+  _$$_RepoPaginationStateCopyWith<_$_RepoPaginationState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/feature/github_repo/pagination/pagination_notifier.dart
+++ b/lib/feature/github_repo/pagination/pagination_notifier.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:github_repo_search/core/exceptions/api_error_response_exception.dart';
+import 'package:github_repo_search/core/model/github_repos_state.dart';
+import 'package:github_repo_search/core/model/pagination_state.dart';
+import 'package:github_repo_search/core/services/api/repo_search_client.dart';
+import 'package:github_repo_search/core/services/model/repo_search_request_param.dart';
+import 'package:github_repo_search/feature/github_repo/pagination/model/repo_pagination_state.dart';
+import 'package:github_repo_search/feature/github_repo/provider/search_query_provider.dart';
+import 'package:github_repo_search/utils/logger.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// ページングプロバイダー
+final pageProvider = StateNotifierProvider<PaginationNotifier,
+    PaginationState<RepoPaginationState>>(
+  (ref) {
+    final searchQuery = ref.watch(searchQueryProvider);
+    final queryParam = RepoSearchRequestParam(q: searchQuery, perPage: 10);
+    return PaginationNotifier(
+      fetchNextItems: (RepoSearchRequestParam? param) async {
+        return ref.watch(repoSearchClientProvider).get(
+              queryParameters: param?.toJson() ?? queryParam.toJson(),
+              fromJson: (json) => RepoPaginationState.update(
+                GithubReposState.fromJson(json),
+                param ?? queryParam,
+              ),
+            );
+      },
+      repoPaginationState: RepoPaginationState(
+        param: queryParam,
+      ),
+    );
+  },
+);
+
+class PaginationNotifier
+    extends StateNotifier<PaginationState<RepoPaginationState>> {
+  PaginationNotifier({
+    required this.fetchNextItems,
+    required this.repoPaginationState,
+  }) : super(const PaginationState.loading()) {
+    fetchFirstBatch();
+  }
+
+  final Future<RepoPaginationState> Function(RepoSearchRequestParam? param)
+      fetchNextItems;
+  RepoPaginationState repoPaginationState;
+
+  void updateData(RepoPaginationState result) {
+    repoPaginationState = repoPaginationState.copyWith(
+      totalCount: result.totalCount,
+      items: repoPaginationState.items + result.items,
+      param: result.param,
+    );
+    state = PaginationState.data(repoPaginationState);
+  }
+
+  Future<void> fetchFirstBatch() async {
+    try {
+      state = const PaginationState.loading();
+
+      final result = await fetchNextItems(null);
+      updateData(result);
+    } on ApiErrorResponseException catch (error, stack) {
+      state = PaginationState.error(error, stack);
+    }
+  }
+
+  Future<void> fetchNextBatch() async {
+    if (state == PaginationState.onGoingLoading(repoPaginationState)) {
+      logger.info('実行中');
+      return;
+    }
+
+    state = PaginationState.onGoingLoading(repoPaginationState);
+
+    try {
+      final result = await fetchNextItems(
+        repoPaginationState.param.copyWith(
+          q: repoPaginationState.param.q,
+          page: repoPaginationState.param.page + 1,
+        ),
+      );
+
+      updateData(result);
+    } on ApiErrorResponseException catch (error, stack) {
+      logger.shout('APIエラー発生');
+      state = PaginationState.onGoingError(repoPaginationState, error, stack);
+    }
+  }
+}

--- a/lib/feature/github_repo/presentation/widgets/repo_list.builder.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.builder.dart
@@ -1,26 +1,42 @@
 import 'package:flutter/material.dart';
+import 'package:github_repo_search/core/widgets/smart_refresher_custom.dart';
 import 'package:github_repo_search/feature/github_repo/model/github_repo.dart';
 import 'package:github_repo_search/feature/github_repo/presentation/widgets/repo_tile.dart';
+import 'package:pull_to_refresh_flutter3/pull_to_refresh_flutter3.dart';
 
 class RepoListBuilder extends StatelessWidget {
   const RepoListBuilder({
     super.key,
     required this.repos,
+    required this.onLoading,
   });
 
   final List<GithubRepo> repos;
+  final VoidCallback onLoading;
 
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      itemBuilder: (context, index) {
-        final repo = repos[index];
-        return RepoTile(repository: repo);
+    final refreshController = RefreshController();
+    return SmartRefresher(
+      controller: refreshController,
+      footer: const SmartRefreshFooter(),
+      enablePullDown: false,
+      enablePullUp: true,
+      physics: const BouncingScrollPhysics(),
+      onLoading: () {
+        onLoading();
+        refreshController.loadComplete();
       },
-      separatorBuilder: (context, index) {
-        return const Divider();
-      },
-      itemCount: repos.length,
+      child: ListView.separated(
+        itemBuilder: (context, index) {
+          final repo = repos[index];
+          return RepoTile(repository: repo);
+        },
+        separatorBuilder: (context, index) {
+          return const Divider();
+        },
+        itemCount: repos.length,
+      ),
     );
   }
 }

--- a/lib/feature/github_repo/presentation/widgets/repo_list.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:github_repo_search/feature/github_repo/pagination/pagination_notifier.dart';
 import 'package:github_repo_search/feature/github_repo/presentation/widgets/repo_list.builder.dart';
-import 'package:github_repo_search/feature/github_repo/provider/repo_search_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class RepoList extends ConsumerWidget {
@@ -8,9 +8,10 @@ class RepoList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final searchResult = ref.watch(repoSearchProvider);
+    final page = ref.watch(pageProvider);
+    final onLoadFunction = ref.watch(pageProvider.notifier).fetchNextBatch;
     return Expanded(
-      child: searchResult.when(
+      child: page.when(
         data: (data) {
           return data.items.isEmpty
               ? const Center(
@@ -18,6 +19,7 @@ class RepoList extends ConsumerWidget {
                 )
               : RepoListBuilder(
                   repos: data.items,
+                  onLoading: onLoadFunction,
                 );
         },
         loading: () => const Center(
@@ -28,6 +30,18 @@ class RepoList extends ConsumerWidget {
             child: Text(
               error.toString(),
             ),
+          );
+        },
+        onGoingError: (previousData, e, stk) {
+          return RepoListBuilder(
+            repos: previousData.items,
+            onLoading: onLoadFunction,
+          );
+        },
+        onGoingLoading: (previousData) {
+          return RepoListBuilder(
+            repos: previousData.items,
+            onLoading: onLoadFunction,
           );
         },
       ),

--- a/lib/feature/github_repo/presentation/widgets/repo_list.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:github_repo_search/core/widgets/retry_button.dart';
 import 'package:github_repo_search/feature/github_repo/pagination/pagination_notifier.dart';
 import 'package:github_repo_search/feature/github_repo/presentation/widgets/repo_list.builder.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -9,7 +10,7 @@ class RepoList extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final page = ref.watch(pageProvider);
-    final onLoadFunction = ref.watch(pageProvider.notifier).fetchNextBatch;
+    final pagingController = ref.watch(pageProvider.notifier);
     return Expanded(
       child: page.when(
         data: (data) {
@@ -19,16 +20,18 @@ class RepoList extends ConsumerWidget {
                 )
               : RepoListBuilder(
                   repos: data.items,
-                  onLoading: onLoadFunction,
+                  onLoading: pagingController.fetchNextBatch,
                 );
         },
         loading: () => const Center(
           child: CircularProgressIndicator(),
         ),
         error: (error, stack) {
-          return Center(
-            child: Text(
-              error.toString(),
+          return RetryButton(
+            title: error.toString(),
+            textButton: ElevatedButton(
+              onPressed: pagingController.fetchFirstBatch,
+              child: const Text('再試行'),
             ),
           );
         },
@@ -47,13 +50,13 @@ class RepoList extends ConsumerWidget {
 
           return RepoListBuilder(
             repos: previousData.items,
-            onLoading: onLoadFunction,
+            onLoading: pagingController.fetchNextBatch,
           );
         },
         onGoingLoading: (previousData) {
           return RepoListBuilder(
             repos: previousData.items,
-            onLoading: onLoadFunction,
+            onLoading: pagingController.fetchNextBatch,
           );
         },
       ),

--- a/lib/feature/github_repo/presentation/widgets/repo_list.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.dart
@@ -32,7 +32,19 @@ class RepoList extends ConsumerWidget {
             ),
           );
         },
-        onGoingError: (previousData, e, stk) {
+        onGoingError: (previousData, error, stack) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  error.toString(),
+                ),
+                duration: const Duration(milliseconds: 1500),
+              ),
+            );
+          });
+
           return RepoListBuilder(
             repos: previousData.items,
             onLoading: onLoadFunction,

--- a/lib/feature/github_repo/provider/repo_search_provider.dart
+++ b/lib/feature/github_repo/provider/repo_search_provider.dart
@@ -1,13 +1,19 @@
 import 'package:github_repo_search/core/model/github_repos_state.dart';
 import 'package:github_repo_search/core/services/api/repo_search_client.dart';
+import 'package:github_repo_search/core/services/model/repo_search_request_param.dart';
 import 'package:github_repo_search/feature/github_repo/provider/search_query_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final repoSearchProvider = FutureProvider((ref) {
   final searchQuery = ref.watch(searchQueryProvider);
+  final requestParam = RepoSearchRequestParam(
+    q: searchQuery,
+    perPage: 10,
+    page: 2,
+  );
 
   return ref.watch(repoSearchClientProvider).get(
-    queryParameters: <String, dynamic>{'q': searchQuery},
-    fromJson: GithubReposState.fromJson,
-  );
+        queryParameters: requestParam.toJson(),
+        fromJson: GithubReposState.fromJson,
+      );
 });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -382,6 +382,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
+  pull_to_refresh_flutter3:
+    dependency: "direct main"
+    description:
+      name: pull_to_refresh_flutter3
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   riverpod:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -228,6 +228,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  gap:
+    dependency: "direct main"
+    description:
+      name: gap
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   flutter_hooks: ^0.18.5+1
   freezed_annotation: ^2.1.0
+  gap: ^2.0.0
   hooks_riverpod: ^1.0.4
   http: ^0.13.5
   json_annotation: ^4.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   hooks_riverpod: ^1.0.4
   http: ^0.13.5
   json_annotation: ^4.6.0
+  pull_to_refresh_flutter3: ^2.0.1
   simple_logger: ^1.9.0
 
 dev_dependencies:


### PR DESCRIPTION
### ページング機能の追加
- リクエストパラメータをプロパティに持つ`RepoSearchRequestParam`を作成
- [こちら](https://www.freecodecamp.org/news/infinite-pagination-in-flutter-with-riverpod/)を参考にAsyncValueのカスタムクラス`PaginationState<T>`を作成
- ページング処理のUIは[pull_to_refresh_flutter3](https://pub.dev/packages/pull_to_refresh_flutter3)を使用

Closes #8 

<img src='https://user-images.githubusercontent.com/89247188/187943957-43849bec-7c71-45a0-aae2-1382d855c282.gif' width='50%'>
