### PR TITLE
SocketExceptionとTimeoutExceptionに対応

### DIFF
--- a/lib/feature/github_repo/pagination/pagination_notifier.dart
+++ b/lib/feature/github_repo/pagination/pagination_notifier.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:github_repo_search/core/exceptions/api_error_response_exception.dart';
 import 'package:github_repo_search/core/model/github_repos_state.dart';
@@ -62,7 +63,14 @@ class PaginationNotifier
       final result = await fetchNextItems(null);
       updateData(result);
     } on ApiErrorResponseException catch (error, stack) {
+      logger.shout(error);
       state = PaginationState.error(error, stack);
+    } on SocketException catch (error, stack) {
+      logger.shout(error);
+      state = PaginationState.error('インターネットに接続してください', stack);
+    } on TimeoutException catch (error, stack) {
+      logger.shout(error);
+      state = PaginationState.error('タイムアウトになりました。', stack);
     }
   }
 
@@ -86,6 +94,20 @@ class PaginationNotifier
     } on ApiErrorResponseException catch (error, stack) {
       logger.shout('APIエラー発生');
       state = PaginationState.onGoingError(repoPaginationState, error, stack);
+    } on SocketException catch (error, stack) {
+      logger.shout(error);
+      state = PaginationState.onGoingError(
+        repoPaginationState,
+        'インターネットに接続してください',
+        stack,
+      );
+    } on TimeoutException catch (error, stack) {
+      logger.shout(error);
+      state = PaginationState.onGoingError(
+        repoPaginationState,
+        'タイムアウトになりました。',
+        stack,
+      );
     }
   }
 }


### PR DESCRIPTION
### ネットワークエラーのハンドリングを追加
`SocketException`と`TimeoutException`をcatchすることで適したエラー文を表示。

Closes #4 

- SocketException

|初回レスポンスエラー|ページング中エラー|
| :---: | :---: |
|<img src='https://user-images.githubusercontent.com/89247188/187961468-626d8e76-c098-4d17-99fd-219a5aaeb91b.png' width='50%'>|<img src='https://user-images.githubusercontent.com/89247188/187961476-665aa7aa-f6a0-4228-a0d2-b1d4182cd146.png' width='50%'>|


- TimeoutException

|初回レスポンスエラー|ページング中エラー|
| :---: | :---: |
|<img src='https://user-images.githubusercontent.com/89247188/187961461-e3eb831c-e82b-45a0-a06b-4f3a61962502.png' width='50%'>|<img src='https://user-images.githubusercontent.com/89247188/187961472-a8a07767-781d-4005-89ff-b594c3495b9d.png' width='50%'>|
