### PR TITLE
PaginationNotifierのmountedを利用してdispose実行の有無を確認

### DIFF
--- a/lib/feature/github_repo/pagination/pagination_notifier.dart
+++ b/lib/feature/github_repo/pagination/pagination_notifier.dart
@@ -43,11 +43,19 @@ class PaginationNotifier
     fetchFirstBatch();
   }
 
+  // disposeされたかどうか判定(dispose = false)
+  @override
+  bool get mounted => super.mounted;
+
   final Future<RepoPaginationState> Function(RepoSearchRequestParam? param)
       fetchNextItems;
   RepoPaginationState repoPaginationState;
 
   void updateData(RepoPaginationState result) {
+    if (mounted == false) {
+      logger.info('mounted false');
+      return;
+    }
     repoPaginationState = repoPaginationState.copyWith(
       totalCount: result.totalCount,
       items: repoPaginationState.items + result.items,


### PR DESCRIPTION
### StateNotifierクラスのmountedをdisposeの有無チェックに使用

検索キーワードが更新され、pageProviderが破棄されると
PaginationNotifierのstateを更新しないように修正できました。