### PR TITLE
ThemeModeをユーザが指定できるように変更

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:github_repo_search/core/model/github_repos_state.dart';
 import 'package:github_repo_search/core/res/app_theme.dart';
 import 'package:github_repo_search/core/services/api/repo_search_client.dart';
-import 'package:github_repo_search/feature/github_repo/presentation/pages/github_repo_list_page.dart';
+import 'package:github_repo_search/feature/navigation/navigation_page.dart';
 import 'package:github_repo_search/utils/logger.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -15,7 +15,7 @@ class App extends StatelessWidget {
       title: 'GitHub Search App',
       theme: appTheme,
       darkTheme: appThemeDark,
-      home: const GithubRepoListPage(),
+      home: const NavigationPage(),
     );
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,18 +3,20 @@ import 'package:github_repo_search/core/model/github_repos_state.dart';
 import 'package:github_repo_search/core/res/app_theme.dart';
 import 'package:github_repo_search/core/services/api/repo_search_client.dart';
 import 'package:github_repo_search/feature/navigation/navigation_page.dart';
+import 'package:github_repo_search/feature/setting/theme_controller.dart';
 import 'package:github_repo_search/utils/logger.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class App extends StatelessWidget {
+class App extends ConsumerWidget {
   const App({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return MaterialApp(
       title: 'GitHub Search App',
       theme: appTheme,
       darkTheme: appThemeDark,
+      themeMode: ref.watch(themeSelectorProvider),
       home: const NavigationPage(),
     );
   }

--- a/lib/core/extension/theme_mode_extension.dart
+++ b/lib/core/extension/theme_mode_extension.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+extension ThemeModeExtension on ThemeMode {
+  String get subtitle {
+    switch (this) {
+      case ThemeMode.system:
+        return '端末の設定';
+      case ThemeMode.light:
+        return 'ライトモード';
+      case ThemeMode.dark:
+        return 'ダークモード';
+    }
+  }
+
+  IconData get iconData {
+    switch (this) {
+      case ThemeMode.system:
+        return Icons.settings;
+      case ThemeMode.light:
+        return Icons.light_mode;
+      case ThemeMode.dark:
+        return Icons.dark_mode;
+    }
+  }
+}

--- a/lib/core/res/app_theme.dart
+++ b/lib/core/res/app_theme.dart
@@ -51,8 +51,8 @@ ThemeData get appTheme {
         ),
       ),
     ),
-    iconTheme: base.iconTheme.copyWith(
-      color: base.primaryColor,
+    iconTheme: const IconThemeData(
+      color: ColorName.textColor,
     ),
     dividerTheme: base.dividerTheme.copyWith(
       color: ColorName.textSubColor.withAlpha(100),
@@ -124,8 +124,8 @@ ThemeData get appThemeDark {
         ),
       ),
     ),
-    iconTheme: base.iconTheme.copyWith(
-      color: base.primaryColor,
+    iconTheme: const IconThemeData(
+      color: ColorName.textSubColorDark,
     ),
     dividerTheme: base.dividerTheme.copyWith(
       color: ColorName.textSubColorDark.withAlpha(150),

--- a/lib/core/res/app_theme.dart
+++ b/lib/core/res/app_theme.dart
@@ -7,7 +7,6 @@ ThemeData get appTheme {
     brightness: Brightness.light,
   );
   return base.copyWith(
-    primaryColor: ColorName.primary,
     buttonTheme: base.buttonTheme.copyWith(
       buttonColor: ColorName.primary,
       textTheme: ButtonTextTheme.normal,

--- a/lib/feature/navigation/navigation_page.dart
+++ b/lib/feature/navigation/navigation_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:github_repo_search/feature/github_repo/presentation/pages/github_repo_list_page.dart';
+import 'package:github_repo_search/feature/setting/setting_page.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+enum PageType {
+  /// リポジトリ一覧
+  repos,
+
+  /// セッティング
+  setting,
+}
+
+/// ページタイププロバイダー
+final pageController = StateProvider<PageType>(
+  (ref) => PageType.repos,
+);
+
+class NavigationPage extends ConsumerWidget {
+  const NavigationPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentPage = ref.watch(pageController.state);
+
+    const pages = [
+      GithubRepoListPage(),
+      SettingPage(),
+    ];
+
+    final bottomNavigationBarItems = [
+      const BottomNavigationBarItem(
+        icon: Icon(
+          Icons.manage_search_outlined,
+        ),
+        label: '検索',
+      ),
+      const BottomNavigationBarItem(
+        icon: Icon(
+          Icons.settings,
+        ),
+        label: '設定',
+      ),
+    ];
+
+    return Scaffold(
+      body: pages[currentPage.state.index],
+      bottomNavigationBar: BottomNavigationBar(
+        items: bottomNavigationBarItems,
+        currentIndex: currentPage.state.index,
+        onTap: (int index) =>
+            currentPage.update((state) => PageType.values[index]),
+        type: BottomNavigationBarType.fixed,
+      ),
+    );
+  }
+}

--- a/lib/feature/setting/setting_page.dart
+++ b/lib/feature/setting/setting_page.dart
@@ -1,14 +1,51 @@
 import 'package:flutter/material.dart';
+import 'package:github_repo_search/core/extension/theme_mode_extension.dart';
+import 'package:github_repo_search/feature/setting/theme_controller.dart';
+import 'package:github_repo_search/gen/colors.gen.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class SettingPage extends StatelessWidget {
+class SettingPage extends ConsumerWidget {
   const SettingPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    // <StateNotifier>ThemeSelectorのインスタンスを監視
+    final themeSelector = ref.watch(themeSelectorProvider.notifier);
+    // 現在選択されているThemeModeを監視
+    final currentThemeMode = ref.watch(themeSelectorProvider);
     return Scaffold(
-      appBar: AppBar(title: const Text('設定')),
-      body: const Center(
-        child: Text('設定画面'),
+      appBar: AppBar(
+        title: const Text('ThemeMode select'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView.builder(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                itemCount: ThemeMode.values.length,
+                itemBuilder: (_, index) {
+                  final themeMode = ThemeMode.values[index];
+                  return RadioListTile<ThemeMode>(
+                    activeColor: ColorName.primary,
+                    value: themeMode, // ラジオボタンのvalue(ThemeModeのenum)
+                    groupValue: currentThemeMode, // 現在選択されているボタン
+                    onChanged: (newTheme) {
+                      themeSelector.changeAndSave(newTheme!);
+                    },
+
+                    title: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Icon(themeMode.iconData),
+                    ),
+                    subtitle: Text(themeMode.subtitle),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/feature/setting/setting_page.dart
+++ b/lib/feature/setting/setting_page.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:github_repo_search/core/extension/context_extension.dart';
 import 'package:github_repo_search/core/extension/theme_mode_extension.dart';
@@ -5,11 +7,55 @@ import 'package:github_repo_search/feature/setting/theme_controller.dart';
 import 'package:github_repo_search/gen/colors.gen.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class SettingPage extends ConsumerWidget {
+class SettingPage extends ConsumerStatefulWidget {
   const SettingPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  SettingPageState createState() => SettingPageState();
+}
+
+class SettingPageState extends ConsumerState<SettingPage>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _rotateAnimation;
+
+  /// アニメーション実行
+  void _animationChange() {
+    // 一度リセットしてから実行
+    _controller
+      ..reset()
+      ..forward();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(seconds: 1),
+      vsync: this,
+    );
+
+    // コントローラーの監視
+    _controller.addListener(() {
+      setState(() {});
+    });
+
+    ///アニメーションの挙動
+    _rotateAnimation = Tween<double>(
+      begin: 0,
+      end: 2 * pi,
+    ).animate(_controller);
+  }
+
+  /// コントローラー破棄
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     // <StateNotifier>ThemeSelectorのインスタンスを監視
     final themeSelector = ref.watch(themeSelectorProvider.notifier);
     // 現在選択されているThemeModeを監視
@@ -32,15 +78,29 @@ class SettingPage extends ConsumerWidget {
                     activeColor: context.isDark
                         ? ColorName.primary.withOpacity(0.8)
                         : ColorName.primary,
-                    value: themeMode, // ラジオボタンのvalue(ThemeModeのenum)
-                    groupValue: currentThemeMode, // 現在選択されているボタン
+                    value: themeMode,
+                    groupValue: currentThemeMode,
                     onChanged: (newTheme) {
+                      /// Themeの保存
                       themeSelector.changeAndSave(newTheme!);
-                    },
 
+                      /// アニメーション実行
+                      _animationChange();
+                    },
                     title: Align(
                       alignment: Alignment.centerLeft,
-                      child: Icon(themeMode.iconData),
+
+                      /// 選択されたThemeのIconだけがアニメーションを実行
+                      child: currentThemeMode == themeMode
+                          ? AnimatedBuilder(
+                              animation: _controller,
+                              builder: (BuildContext context, child) => child!,
+                              child: Transform.rotate(
+                                angle: _rotateAnimation.value,
+                                child: Icon(themeMode.iconData),
+                              ),
+                            )
+                          : Icon(themeMode.iconData),
                     ),
                     subtitle: Text(themeMode.subtitle),
                     selected: currentThemeMode == themeMode,

--- a/lib/feature/setting/setting_page.dart
+++ b/lib/feature/setting/setting_page.dart
@@ -40,6 +40,7 @@ class SettingPage extends ConsumerWidget {
                       child: Icon(themeMode.iconData),
                     ),
                     subtitle: Text(themeMode.subtitle),
+                    selected: currentThemeMode == themeMode,
                   );
                 },
               ),

--- a/lib/feature/setting/setting_page.dart
+++ b/lib/feature/setting/setting_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:github_repo_search/core/extension/context_extension.dart';
 import 'package:github_repo_search/core/extension/theme_mode_extension.dart';
 import 'package:github_repo_search/feature/setting/theme_controller.dart';
 import 'package:github_repo_search/gen/colors.gen.dart';
@@ -28,7 +29,9 @@ class SettingPage extends ConsumerWidget {
                 itemBuilder: (_, index) {
                   final themeMode = ThemeMode.values[index];
                   return RadioListTile<ThemeMode>(
-                    activeColor: ColorName.primary,
+                    activeColor: context.isDark
+                        ? ColorName.primary.withOpacity(0.8)
+                        : ColorName.primary,
                     value: themeMode, // ラジオボタンのvalue(ThemeModeのenum)
                     groupValue: currentThemeMode, // 現在選択されているボタン
                     onChanged: (newTheme) {

--- a/lib/feature/setting/setting_page.dart
+++ b/lib/feature/setting/setting_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class SettingPage extends StatelessWidget {
+  const SettingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('設定')),
+      body: const Center(
+        child: Text('設定画面'),
+      ),
+    );
+  }
+}

--- a/lib/feature/setting/theme_controller.dart
+++ b/lib/feature/setting/theme_controller.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:github_repo_search/utils/provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// SharedPreferences で使用するテーマ保存用のキー
+const _themePrefsKey = 'selectedTheme';
+
+final themeSelectorProvider =
+    StateNotifierProvider<ThemeModeNotifier, ThemeMode>(
+  (ref) => ThemeModeNotifier(ref.read),
+);
+
+class ThemeModeNotifier extends StateNotifier<ThemeMode> {
+  ThemeModeNotifier(this._read) : super(ThemeMode.system) {
+    /// `SharedPreferences` を使用して、記憶しているテーマがあれば取得して反映する。
+    final themeIndex = _prefs.getInt(_themePrefsKey);
+    if (themeIndex == null) {
+      return;
+    }
+    final themeMode = ThemeMode.values.firstWhere(
+      (e) => e.index == themeIndex,
+      orElse: () => ThemeMode.system,
+    );
+    state = themeMode;
+  }
+
+  final Reader _read;
+
+  /// 選択したテーマを保存するためのローカル保存領域
+  late final _prefs = _read(sharedPreferencesProvider);
+
+  /// テーマの変更と保存を行う
+  Future<void> changeAndSave(ThemeMode theme) async {
+    await _prefs.setInt(_themePrefsKey, theme.index);
+    state = theme;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:github_repo_search/utils/logger.dart';
+import 'package:github_repo_search/utils/provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   Logger.configure();
 
-  runApp(const ProviderScope(child: App()));
+  runApp(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(
+          await SharedPreferences.getInstance(),
+        )
+      ],
+      child: const App(),
+    ),
+  );
 }

--- a/lib/utils/provider.dart
+++ b/lib/utils/provider.dart
@@ -1,0 +1,6 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final sharedPreferencesProvider = Provider<SharedPreferences>(
+  (ref) => throw UnimplementedError(),
+);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -256,6 +256,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   freezed:
     dependency: "direct dev"
     description:
@@ -543,6 +548,62 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.15"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.12"
+  shared_preferences_ios:
+    dependency: transitive
+    description:
+      name: shared_preferences_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   intl: ^0.17.0
   json_annotation: ^4.6.0
   pull_to_refresh_flutter3: ^2.0.1
+  shared_preferences: ^2.0.15
   simple_logger: ^1.9.0
 
 dev_dependencies:


### PR DESCRIPTION
### ナビゲーション
BottomNavigationBarで制御。
- リポジトリ一覧ページ
- 設定ページ

### ThemeModeの指定
`class ThemeModeNotifier extends StateNotifier<ThemeMode>`クラスで
SharedPreferenceとデータの仲介を行う。

`App`クラスをConsumerWidgetに変更し、themeModeをwatchする。

アイコンにアニメーション機能を追加


#### ThemeModeの拡張クラスを作成
subTitleとiconDataを保持

### デモ動画

|端末設定|ライトモード固定|ダークモード固定|
| :---: | :---: | :---: |
|<img src = 'https://user-images.githubusercontent.com/89247188/188307104-ebcc1f22-344d-4efe-bae3-488dff297071.gif' width = '220'>|<img src = 'https://user-images.githubusercontent.com/89247188/188306992-93e68282-cd6d-4920-bc36-4b2077776b5c.gif' width = '220'>|<img src = 'https://user-images.githubusercontent.com/89247188/188306900-3e3cbc7b-8fc7-4a71-bad0-02bd432563e4.gif' width = '220'>|
| （初め）端末設定:ライトモード<br>（変更）端末設定:ダークモード |（初め）端末設定:ライトモード<br>（変更）端末設定:ダークモード|（初め）端末設定:ダークモード<br>（変更）端末設定:ライトモード|

- アニメーション
<img src = 'https://user-images.githubusercontent.com/89247188/188306907-a3f66fd7-5a9c-4c36-8864-59d4b571850f.gif' width = '250'>


