### PR TITLE
合計レポジトリ数の表示機能を追加

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:github_repo_search/core/model/github_repos_state.dart';
 import 'package:github_repo_search/core/res/app_theme.dart';
-import 'package:github_repo_search/core/services/api/repo_search_client.dart';
 import 'package:github_repo_search/feature/navigation/navigation_page.dart';
 import 'package:github_repo_search/feature/setting/theme_controller.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
-import 'package:github_repo_search/utils/logger.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class App extends ConsumerWidget {
@@ -27,32 +24,6 @@ class App extends ConsumerWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       home: const NavigationPage(),
-    );
-  }
-}
-
-class MyHomePage extends ConsumerWidget {
-  const MyHomePage({super.key});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('GitHub'),
-      ),
-      body: const Center(
-        child: Text('Let\'s start the program!'),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () async {
-          final items = await ref.watch(repoSearchClientProvider).get(
-            queryParameters: <String, dynamic>{'q': 'YUMEMI'},
-            fromJson: GithubReposState.fromJson,
-          );
-          logger.info(items);
-        },
-        child: const Icon(Icons.search),
-      ),
     );
   }
 }

--- a/lib/feature/github_repo/presentation/pages/github_repo_list_page.dart
+++ b/lib/feature/github_repo/presentation/pages/github_repo_list_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:github_repo_search/core/extension/context_extension.dart';
 import 'package:github_repo_search/feature/github_repo/presentation/widgets/repo_list.dart';
+import 'package:github_repo_search/feature/github_repo/presentation/widgets/total_count_bar.dart';
 import 'package:github_repo_search/feature/github_repo/search_form/search_form.dart';
 
 class GithubRepoListPage extends StatelessWidget {
@@ -24,6 +25,7 @@ class GithubRepoListPage extends StatelessWidget {
           child: Column(
             children: const [
               SearchFrom(),
+              TotalCountBar(),
               RepoList(),
             ],
           ),

--- a/lib/feature/github_repo/presentation/widgets/repo_list.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.dart
@@ -3,6 +3,7 @@ import 'package:github_repo_search/core/extension/context_extension.dart';
 import 'package:github_repo_search/core/widgets/retry_button.dart';
 import 'package:github_repo_search/feature/github_repo/pagination/pagination_notifier.dart';
 import 'package:github_repo_search/feature/github_repo/presentation/widgets/repo_list.builder.dart';
+import 'package:github_repo_search/feature/github_repo/presentation/widgets/total_count_bar.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -16,6 +17,11 @@ class RepoList extends ConsumerWidget {
     return Expanded(
       child: page.when(
         data: (data) {
+          WidgetsBinding.instance.addPostFrameCallback(
+            (_) => ref
+                .watch(totalCountProvider.state)
+                .update((state) => data.totalCount),
+          );
           return data.items.isEmpty
               ? Center(
                   child: Text(i18n.notFound),
@@ -29,6 +35,9 @@ class RepoList extends ConsumerWidget {
           child: CircularProgressIndicator(),
         ),
         error: (error, stack) {
+          WidgetsBinding.instance.addPostFrameCallback(
+            (_) => ref.watch(totalCountProvider.state).update((state) => null),
+          );
           return RetryButton(
             title: error.toString(),
             textButton: ElevatedButton(

--- a/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
+++ b/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final totalCountProvider = StateProvider<int?>((_) => null);
+
+class TotalCountBar extends ConsumerWidget {
+  const TotalCountBar({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final totalCount = ref.watch(totalCountProvider);
+    return SizedBox(
+      width: double.infinity,
+      child: Align(
+        alignment: Alignment.centerRight,
+        child: totalCount != null ? Text('合計$totalCount件') : null,
+      ),
+    );
+  }
+}

--- a/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
+++ b/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:github_repo_search/core/extension/num_extension.dart';
+import 'package:github_repo_search/i18n/translations.g.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final totalCountProvider = StateProvider<int?>((_) => null);
@@ -14,7 +15,9 @@ class TotalCountBar extends ConsumerWidget {
       width: double.infinity,
       child: Align(
         alignment: Alignment.centerRight,
-        child: totalCount != null ? Text('合計${totalCount.formatComma}件') : null,
+        child: totalCount != null
+            ? Text(i18n.totalRepo(totalCount: totalCount.formatComma))
+            : null,
       ),
     );
   }

--- a/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
+++ b/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:github_repo_search/core/extension/num_extension.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final totalCountProvider = StateProvider<int?>((_) => null);
@@ -13,7 +14,7 @@ class TotalCountBar extends ConsumerWidget {
       width: double.infinity,
       child: Align(
         alignment: Alignment.centerRight,
-        child: totalCount != null ? Text('合計$totalCount件') : null,
+        child: totalCount != null ? Text('合計${totalCount.formatComma}件') : null,
       ),
     );
   }

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -9,6 +9,7 @@
     "fork" : "fork",
     "issue" : "issue",
     "search" : "Search Repository",
+    "totalRepo" : "Total: $totalCount",
     "settingTitle" : "Settings",
     "themeTerminate" : "Terminal Settings",
     "themeLightMode" : "Light Mode",

--- a/lib/i18n/strings_ja.i18n.json
+++ b/lib/i18n/strings_ja.i18n.json
@@ -9,6 +9,7 @@
     "fork" : "フォーク数",
     "issue" : "イシュー数",
     "search" : "レポジトリを検索",
+    "totalRepo" : "合計$totalCount件",
     "settingTitle" : "設定",
     "themeTerminate" : "端末の設定",
     "themeLightMode" : "ライトモード",

--- a/lib/i18n/translations.g.dart
+++ b/lib/i18n/translations.g.dart
@@ -2,7 +2,7 @@
  * Generated file. Do not edit.
  *
  * Locales: 2
- * Strings: 52 (26.0 per locale)
+ * Strings: 54 (27.0 per locale)
  */
 
 import 'package:flutter/widgets.dart';
@@ -317,6 +317,7 @@ class _TranslationsEn {
   String get fork => 'fork';
   String get issue => 'issue';
   String get search => 'Search Repository';
+  String totalRepo({required Object totalCount}) => 'Total: $totalCount';
   String get settingTitle => 'Settings';
   String get themeTerminate => 'Terminal Settings';
   String get themeLightMode => 'Light Mode';
@@ -364,6 +365,8 @@ class _TranslationsJa implements _TranslationsEn {
   String get issue => 'イシュー数';
   @override
   String get search => 'レポジトリを検索';
+  @override
+  String totalRepo({required Object totalCount}) => '合計$totalCount件';
   @override
   String get settingTitle => '設定';
   @override


### PR DESCRIPTION
### 動作
- APIレスポンスの取得と同期
- エラーの時は何も表示しない
- ローディング中エラーは前回値を表示
- 結果が0件の時は0件を表示

|取得成功|初回エラー|
| :---: | :---: |
|<img src = 'https://user-images.githubusercontent.com/89247188/188371363-7b00f878-8723-45ba-beec-a6fdfcfa80cc.gif' width = '250'>|<img src = 'https://user-images.githubusercontent.com/89247188/188371234-c76982b3-a6a0-4a4b-907b-3af3f74f3ae4.png' width = '250'>|
