### PR TITLE
画面回転時の不具合を修正

### DIFF
--- a/lib/feature/github_repo/presentation/pages/github_repo_list_page.dart
+++ b/lib/feature/github_repo/presentation/pages/github_repo_list_page.dart
@@ -10,15 +10,17 @@ class GithubRepoListPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      resizeToAvoidBottomInset: false,
-      appBar: AppBar(
-        title: const Text('GitHub'),
-        flexibleSpace: GestureDetector(
-          onTap: () {
-            context.hideKeyboard();
-          },
-        ),
-      ),
+      resizeToAvoidBottomInset: true,
+      appBar: context.isLandscape
+          ? null
+          : AppBar(
+              title: const Text('GitHub'),
+              flexibleSpace: GestureDetector(
+                onTap: () {
+                  context.hideKeyboard();
+                },
+              ),
+            ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12),

--- a/lib/feature/github_repo/presentation/pages/github_repo_list_page.dart
+++ b/lib/feature/github_repo/presentation/pages/github_repo_list_page.dart
@@ -10,7 +10,7 @@ class GithubRepoListPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      resizeToAvoidBottomInset: true,
+      resizeToAvoidBottomInset: false,
       appBar: context.isLandscape
           ? null
           : AppBar(
@@ -24,12 +24,19 @@ class GithubRepoListPage extends StatelessWidget {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: Column(
-            children: const [
-              SearchFrom(),
-              TotalCountBar(),
-              RepoList(),
-            ],
+          child: SingleChildScrollView(
+            physics: const NeverScrollableScrollPhysics(),
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            child: SizedBox(
+              height: context.deviceHeight * 0.8,
+              child: Column(
+                children: const [
+                  SearchFrom(),
+                  TotalCountBar(),
+                  RepoList(),
+                ],
+              ),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
### 概要
キーボードを表示したまま画面回転が行われるとレンダリングエラーが生じていた。 #25 

### 解決方法
GithubRepoListPageをSingleChildScrollViewでラップし、
プロパティに以下を指定
```
/// スクロールを禁止
physics: const NeverScrollableScrollPhysics(), 
/// ListViewでスクロールされるとキーボードを閉じる
keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag, 
```
また、横画面の時はAppBarを表示しないようにして画面の圧迫感を緩和

### デモ
<img src = 'https://user-images.githubusercontent.com/89247188/188408068-24c9ceaa-a985-48e8-b31a-2c3f446bac14.gif' width = 400>
