### PR TITLE
リポジトリを全てを取得した際のハンドリングを更新

### DIFF
--- a/lib/feature/github_repo/pagination/pagination_notifier.dart
+++ b/lib/feature/github_repo/pagination/pagination_notifier.dart
@@ -48,6 +48,9 @@ class PaginationNotifier
   @override
   bool get mounted => super.mounted;
 
+  /// 追加のデータがあるかどうか
+  bool hasNext = true;
+
   final Future<RepoPaginationState> Function(RepoSearchRequestParam? param)
       fetchNextItems;
   RepoPaginationState repoPaginationState;
@@ -63,6 +66,10 @@ class PaginationNotifier
       param: result.param,
     );
     state = PaginationState.data(repoPaginationState);
+
+    if (repoPaginationState.items.length >= repoPaginationState.totalCount) {
+      hasNext = false;
+    }
   }
 
   Future<void> fetchFirstBatch() async {
@@ -84,6 +91,11 @@ class PaginationNotifier
   }
 
   Future<void> fetchNextBatch() async {
+    if (hasNext == false) {
+      logger.info('全て表示');
+      state = PaginationState.onGoingError(repoPaginationState, '全て表示しました。');
+      return;
+    }
     if (state == PaginationState.onGoingLoading(repoPaginationState)) {
       logger.info('実行中');
       return;

--- a/lib/feature/github_repo/pagination/pagination_notifier.dart
+++ b/lib/feature/github_repo/pagination/pagination_notifier.dart
@@ -91,11 +91,6 @@ class PaginationNotifier
   }
 
   Future<void> fetchNextBatch() async {
-    if (hasNext == false) {
-      logger.info('全て表示');
-      state = PaginationState.onGoingError(repoPaginationState, '全て表示しました。');
-      return;
-    }
     if (state == PaginationState.onGoingLoading(repoPaginationState)) {
       logger.info('実行中');
       return;

--- a/lib/feature/github_repo/presentation/widgets/repo_list.builder.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.builder.dart
@@ -9,10 +9,12 @@ class RepoListBuilder extends StatelessWidget {
     super.key,
     required this.repos,
     required this.onLoading,
+    this.hasNext = true,
   });
 
   final List<GithubRepo> repos;
   final VoidCallback onLoading;
+  final bool hasNext;
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +23,7 @@ class RepoListBuilder extends StatelessWidget {
       controller: refreshController,
       footer: const SmartRefreshFooter(),
       enablePullDown: false,
-      enablePullUp: true,
+      enablePullUp: hasNext,
       physics: const BouncingScrollPhysics(),
       onLoading: () {
         onLoading();

--- a/lib/feature/github_repo/presentation/widgets/repo_list.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.dart
@@ -29,6 +29,7 @@ class RepoList extends ConsumerWidget {
               : RepoListBuilder(
                   repos: data.items,
                   onLoading: pagingController.fetchNextBatch,
+                  hasNext: pagingController.hasNext,
                 );
         },
         loading: () => const Center(


### PR DESCRIPTION
 
#27 

- `PaginationNotifier`クラスのhasNextでページング情報があるかチェック
- 更新情報がない場合、スクロールしてもローディングしないように修正



### デモ
<img src = 'https://user-images.githubusercontent.com/89247188/188418410-3ebb4e7e-9e80-49bd-8e41-5ec7dba5ebc6.gif' width = '400'>
