### PR TITLE
NotFoundウィジェットの表示不具合を修正

### DIFF
--- a/lib/feature/github_repo/presentation/widgets/not_found.dart
+++ b/lib/feature/github_repo/presentation/widgets/not_found.dart
@@ -12,7 +12,7 @@ class NotFound extends StatelessWidget {
         padding: const EdgeInsets.all(20),
         child: Column(
           children: [
-            Expanded(child: Assets.images.notFound.image()),
+            Flexible(child: Assets.images.notFound.image()),
             Text(i18n.notFound)
           ],
         ),


### PR DESCRIPTION
### 原因
imageをExpandedでラップしてしまっていた。

### 解決方法
ExpandedをFlexibleに変更。

|修正前|修正後|
| :---: | :---: |
|<img src = 'https://user-images.githubusercontent.com/89247188/188485402-a48a4b02-1f30-4736-ad92-bf195eeb6f82.PNG' width = '250'>|<img src = 'https://user-images.githubusercontent.com/89247188/188485396-ed438e70-39d8-4042-81f1-18067ff5271e.PNG' width = '250'>|