### PR TITLE
取得リポジトリ数を30個/回に変更

### DIFF
--- a/lib/feature/github_repo/pagination/pagination_notifier.dart
+++ b/lib/feature/github_repo/pagination/pagination_notifier.dart
@@ -17,7 +17,7 @@ final pageProvider = StateNotifierProvider<PaginationNotifier,
     PaginationState<RepoPaginationState>>(
   (ref) {
     final searchQuery = ref.watch(searchQueryProvider);
-    final queryParam = RepoSearchRequestParam(q: searchQuery, perPage: 10);
+    final queryParam = RepoSearchRequestParam(q: searchQuery, perPage: 30);
     return PaginationNotifier(
       fetchNextItems: (RepoSearchRequestParam? param) async {
         return ref.watch(repoSearchClientProvider).get(


### PR DESCRIPTION
リクエスト制限を出しやすくするためにperPageを10に<br>
設定していたのでデフォルトの30件に修正。