### PR TITLE
Riverpod パッケージの変更

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/core/res/app_theme.dart';
 import 'package:github_repo_search/feature/navigation/navigation_page.dart';
 import 'package:github_repo_search/feature/setting/theme_controller.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class App extends ConsumerWidget {
   const App({super.key});

--- a/lib/core/services/api/repo_search_client.dart
+++ b/lib/core/services/api/repo_search_client.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/core/exceptions/api_error_response_exception.dart';
 import 'package:github_repo_search/core/services/model/error/client_error.dart';
 import 'package:github_repo_search/utils/logger.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http/http.dart' as http;
 
 import 'api_client.dart';

--- a/lib/feature/github_repo/pagination/pagination_notifier.dart
+++ b/lib/feature/github_repo/pagination/pagination_notifier.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/core/exceptions/api_error_response_exception.dart';
 import 'package:github_repo_search/core/model/github_repos_state.dart';
 import 'package:github_repo_search/core/model/pagination_state.dart';
@@ -10,7 +11,6 @@ import 'package:github_repo_search/feature/github_repo/pagination/model/repo_pag
 import 'package:github_repo_search/feature/github_repo/search_form/search_form_controller.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
 import 'package:github_repo_search/utils/logger.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 // ページングプロバイダー
 final pageProvider = StateNotifierProvider<PaginationNotifier,

--- a/lib/feature/github_repo/presentation/widgets/repo_list.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/core/extension/context_extension.dart';
 import 'package:github_repo_search/core/widgets/retry_button.dart';
 import 'package:github_repo_search/feature/github_repo/pagination/pagination_notifier.dart';
@@ -6,7 +7,6 @@ import 'package:github_repo_search/feature/github_repo/presentation/widgets/not_
 import 'package:github_repo_search/feature/github_repo/presentation/widgets/repo_list.builder.dart';
 import 'package:github_repo_search/feature/github_repo/presentation/widgets/total_count_bar.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class RepoList extends ConsumerWidget {
   const RepoList({super.key});

--- a/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
+++ b/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/core/extension/num_extension.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// トータルカウントプロバイダー
 final totalCountProvider = StateProvider<int?>((_) => null);

--- a/lib/feature/github_repo/search_form/search_form.dart
+++ b/lib/feature/github_repo/search_form/search_form.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/feature/github_repo/search_form/search_form_controller.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class SearchFrom extends ConsumerWidget {
   const SearchFrom({super.key});

--- a/lib/feature/github_repo/search_form/search_form_controller.dart
+++ b/lib/feature/github_repo/search_form/search_form_controller.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
 import 'package:github_repo_search/utils/validation.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// 検索クエリープロバイダー
 final searchQueryProvider = StateNotifierProvider<SearchFormController, String>(

--- a/lib/feature/navigation/navigation_page.dart
+++ b/lib/feature/navigation/navigation_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/feature/github_repo/presentation/pages/github_repo_list_page.dart';
 import 'package:github_repo_search/feature/setting/setting_page.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 enum PageType {
   /// リポジトリ一覧

--- a/lib/feature/setting/setting_page.dart
+++ b/lib/feature/setting/setting_page.dart
@@ -1,12 +1,12 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/core/extension/context_extension.dart';
 import 'package:github_repo_search/core/extension/theme_mode_extension.dart';
 import 'package:github_repo_search/feature/setting/theme_controller.dart';
 import 'package:github_repo_search/gen/colors.gen.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class SettingPage extends ConsumerStatefulWidget {
   const SettingPage({super.key});

--- a/lib/feature/setting/theme_controller.dart
+++ b/lib/feature/setting/theme_controller.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/utils/provider.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// SharedPreferences で使用するテーマ保存用のキー
 const _themePrefsKey = 'selectedTheme';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
 import 'package:github_repo_search/utils/logger.dart';
 import 'package:github_repo_search/utils/provider.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app.dart';

--- a/lib/utils/provider.dart
+++ b/lib/utils/provider.dart
@@ -1,4 +1,4 @@
-import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// ローカルDBプロバイダー

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -258,13 +258,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.3.0"
-  flutter_hooks:
-    dependency: "direct main"
-    description:
-      name: flutter_hooks
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.18.5+1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -350,13 +343,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  hooks_riverpod:
-    dependency: "direct main"
-    description:
-      name: hooks_riverpod
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
   html:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -292,7 +292,7 @@ packages:
     source: hosted
     version: "2.2.8"
   flutter_riverpod:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,13 +13,11 @@ dependencies:
   fast_i18n: ^5.12.6
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.18.5+1
   flutter_localizations:
     sdk: flutter         
   flutter_riverpod: ^1.0.4
   freezed_annotation: ^2.1.0
   gap: ^2.0.0
-  hooks_riverpod: ^1.0.4
   http: ^0.13.5
   intl: ^0.17.0
   json_annotation: ^4.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_hooks: ^0.18.5+1
   flutter_localizations:
     sdk: flutter         
+  flutter_riverpod: ^1.0.4
   freezed_annotation: ^2.1.0
   gap: ^2.0.0
   hooks_riverpod: ^1.0.4


### PR DESCRIPTION
状態管理のパッケージに[hooks_riverpod](https://pub.dev/packages/hooks_riverpod)を使用していたが、[flutter_riverpod](https://pub.dev/packages/flutter_riverpod)に変更する。

- flutter_riverpod パッケージの導入
- hooks_riverpodと[flutter_hooks](https://pub.dev/packages/flutter_hooks)をpubspec.yamlから削除
- flutter_hooksに関しては後に使用する可能性はあるが現状は必要ないので削除
- iOS, Android共に正常に動作