### PR TITLE
リポジトリ詳細ページのデザインを改善

### DIFF
--- a/lib/feature/github_repo/pagination/pagination_notifier.dart
+++ b/lib/feature/github_repo/pagination/pagination_notifier.dart
@@ -83,10 +83,10 @@ class PaginationNotifier
       state = PaginationState.error(error, stack);
     } on SocketException catch (error, stack) {
       logger.shout(error);
-      state = PaginationState.error(i18n.error422Network, stack);
+      state = PaginationState.error(i18n.errorNetwork, stack);
     } on TimeoutException catch (error, stack) {
       logger.shout(error);
-      state = PaginationState.error(i18n.error422Timeout, stack);
+      state = PaginationState.error(i18n.errorTimeout, stack);
     }
   }
 
@@ -114,14 +114,14 @@ class PaginationNotifier
       logger.shout(error);
       state = PaginationState.onGoingError(
         repoPaginationState,
-        i18n.error422Network,
+        i18n.errorNetwork,
         stack,
       );
     } on TimeoutException catch (error, stack) {
       logger.shout(error);
       state = PaginationState.onGoingError(
         repoPaginationState,
-        i18n.error422Timeout,
+        i18n.errorTimeout,
         stack,
       );
     }

--- a/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
+++ b/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
@@ -30,6 +30,7 @@ class GithubRepoDetailPage extends StatelessWidget {
                     color: LanguageColors.getLanguageColor(
                       repository.language,
                     ),
+                    size: 18,
                   ),
                   Text(repository.language!),
                 ],
@@ -158,7 +159,8 @@ class _CustomTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
       decoration: BoxDecoration(
         color: Colors.white70,
         border: Border.all(
@@ -167,7 +169,7 @@ class _CustomTile extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -177,8 +179,11 @@ class _CustomTile extends StatelessWidget {
               Text(title),
             ],
           ),
-          const Divider(),
-          child,
+          const Divider(
+            height: 1,
+            thickness: 3,
+          ),
+          FittedBox(child: child),
         ],
       ),
     );

--- a/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
+++ b/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
@@ -14,6 +14,51 @@ class GithubRepoDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final listMap = [
+      _CustomTile(
+        icon: Icons.language,
+        title: i18n.language,
+        iconColor: Colors.blue,
+        child: repository.language != null
+            ? Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.fiber_manual_record,
+                    color: LanguageColors.getLanguageColor(
+                      repository.language,
+                    ),
+                  ),
+                  Text(repository.language!),
+                ],
+              )
+            : const Text('-'),
+      ),
+      _CustomTile(
+        icon: Icons.star_border,
+        title: i18n.star,
+        iconColor: const Color(0xFFedb918),
+        child: Text(repository.stargazersCount.formatComma),
+      ),
+      _CustomTile(
+        icon: Icons.remove_red_eye_outlined,
+        title: i18n.watch,
+        iconColor: Colors.red,
+        child: Text(repository.watchersCount.formatComma),
+      ),
+      _CustomTile(
+        icon: Icons.fork_left,
+        title: i18n.fork,
+        iconColor: Colors.grey,
+        child: Text(repository.forksCount.formatComma),
+      ),
+      _CustomTile(
+        icon: Icons.adjust,
+        title: i18n.issue,
+        iconColor: Colors.green,
+        child: Text(repository.openIssuesCount.formatComma),
+      ),
+    ];
     return Scaffold(
       appBar: AppBar(
         title: Text(
@@ -24,90 +69,53 @@ class GithubRepoDetailPage extends StatelessWidget {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(12),
-          child: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    CircleThumbnail(
+          child: CustomScrollView(
+            slivers: [
+              SliverList(
+                delegate: SliverChildListDelegate([
+                  Align(
+                    child: CircleThumbnail(
+                      size: 150,
                       url: repository.owner.avatarUrl,
                     ),
-                    const Gap(10),
-                    Text(repository.owner.login),
-                  ],
-                ),
-                Text(
-                  repository.name,
-                  style: context.titleStyle,
-                ),
-                const Gap(10),
-                Container(
-                  padding: const EdgeInsets.all(8),
-                  height: 100,
-                  width: double.infinity,
-                  decoration: BoxDecoration(
-                    border: Border.all(
-                      color: Colors.grey,
-                    ),
-                    borderRadius: BorderRadius.circular(8),
                   ),
-                  child: SingleChildScrollView(
-                    child: Text(
-                      repository.description,
-                      style: context.subTitleStyle,
+                  const Gap(10),
+                  Center(child: Text(repository.owner.login)),
+                  const Gap(30),
+                  Text(
+                    'リポジトリ：${repository.name}',
+                    style: context.titleStyle,
+                  ),
+                  const Gap(10),
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    height: 100,
+                    width: double.infinity,
+                    decoration: BoxDecoration(
+                      color: Colors.white70,
+                      border: Border.all(
+                        color: Colors.grey,
+                      ),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: SingleChildScrollView(
+                      child: Text(
+                        repository.description,
+                        style: context.subTitleStyle,
+                      ),
                     ),
                   ),
-                ),
-                _CustomTile(
-                  icon: Icons.language,
-                  title: i18n.language,
-                  iconColor: Colors.blue,
-                  child: repository.language != null
-                      ? Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(
-                              Icons.fiber_manual_record,
-                              color: context.isDark
-                                  ? LanguageColors.getLanguageColor(
-                                      repository.language,
-                                    )
-                                  : LanguageColors.getLanguageColor(
-                                      repository.language,
-                                    ).withOpacity(0.8),
-                            ),
-                            Text(repository.language!),
-                          ],
-                        )
-                      : const Text('-'),
-                ),
-                _CustomTile(
-                  icon: Icons.star_border,
-                  title: i18n.star,
-                  iconColor: const Color(0xFFedb918),
-                  child: Text(repository.stargazersCount.formatComma),
-                ),
-                _CustomTile(
-                  icon: Icons.remove_red_eye_outlined,
-                  title: i18n.watch,
-                  iconColor: Colors.red,
-                  child: Text(repository.watchersCount.formatComma),
-                ),
-                _CustomTile(
-                  icon: Icons.fork_left,
-                  title: i18n.fork,
-                  iconColor: Colors.grey,
-                  child: Text(repository.forksCount.formatComma),
-                ),
-                _CustomTile(
-                  icon: Icons.adjust,
-                  title: i18n.issue,
-                  iconColor: Colors.green,
-                  child: Text(repository.openIssuesCount.formatComma),
-                ),
-              ],
-            ),
+                  const Gap(20)
+                ]),
+              ),
+              SliverGrid.count(
+                mainAxisSpacing: 10,
+                crossAxisSpacing: 10,
+                childAspectRatio: 2,
+                crossAxisCount: context.isLandscape ? 5 : 2,
+                children: listMap,
+              )
+            ],
           ),
         ),
       ),
@@ -130,18 +138,29 @@ class _CustomTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        ListTile(
-          leading: Icon(
-            icon,
-            color: context.isDark ? iconColor.withOpacity(0.8) : iconColor,
-          ),
-          title: Text(title),
-          trailing: child,
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.white70,
+        border: Border.all(
+          color: context.subTitleStyle.color!,
         ),
-        const Divider(),
-      ],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: iconColor),
+              const Gap(5),
+              Text(title),
+            ],
+          ),
+          const Divider(),
+          child,
+        ],
+      ),
     );
   }
 }

--- a/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
+++ b/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
@@ -15,7 +15,7 @@ class GithubRepoDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     /// SliverGridに表示する要素
-    final listMap = [
+    final repoDetailTiles = [
       /// 言語
       _CustomTile(
         icon: Icons.language,
@@ -123,7 +123,7 @@ class GithubRepoDetailPage extends StatelessWidget {
                 crossAxisSpacing: 10,
                 childAspectRatio: 2,
                 crossAxisCount: context.isLandscape ? 5 : 2,
-                children: listMap,
+                children: repoDetailTiles,
               )
             ],
           ),

--- a/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
+++ b/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
@@ -92,9 +92,19 @@ class GithubRepoDetailPage extends StatelessWidget {
                   const Gap(10),
                   Center(child: Text(repository.owner.login)),
                   const Gap(30),
-                  Text(
-                    'リポジトリ：${repository.name}',
-                    style: context.titleStyle,
+                  RichText(
+                    text: TextSpan(
+                      style: context.titleStyle,
+                      children: [
+                        TextSpan(text: i18n.repository),
+                        TextSpan(
+                          text: repository.name,
+                          style: context.titleStyle.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                   const Gap(10),
                   Container(

--- a/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
+++ b/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
@@ -14,7 +14,9 @@ class GithubRepoDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    /// SliverGridに表示する要素
     final listMap = [
+      /// 言語
       _CustomTile(
         icon: Icons.language,
         title: i18n.language,
@@ -34,24 +36,32 @@ class GithubRepoDetailPage extends StatelessWidget {
               )
             : const Text('-'),
       ),
+
+      /// スター数
       _CustomTile(
         icon: Icons.star_border,
         title: i18n.star,
         iconColor: const Color(0xFFedb918),
         child: Text(repository.stargazersCount.formatComma),
       ),
+
+      /// ウォッチ数
       _CustomTile(
         icon: Icons.remove_red_eye_outlined,
         title: i18n.watch,
         iconColor: Colors.red,
         child: Text(repository.watchersCount.formatComma),
       ),
+
+      /// フォーク数
       _CustomTile(
         icon: Icons.fork_left,
         title: i18n.fork,
         iconColor: Colors.grey,
         child: Text(repository.forksCount.formatComma),
       ),
+
+      /// イシュー数
       _CustomTile(
         icon: Icons.adjust,
         title: i18n.issue,

--- a/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
+++ b/lib/feature/github_repo/presentation/pages/github_repo_detail_page.dart
@@ -42,9 +42,22 @@ class GithubRepoDetailPage extends StatelessWidget {
                   style: context.titleStyle,
                 ),
                 const Gap(10),
-                Text(
-                  repository.description,
-                  style: context.subTitleStyle,
+                Container(
+                  padding: const EdgeInsets.all(8),
+                  height: 100,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: Colors.grey,
+                    ),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: SingleChildScrollView(
+                    child: Text(
+                      repository.description,
+                      style: context.subTitleStyle,
+                    ),
+                  ),
                 ),
                 _CustomTile(
                   icon: Icons.language,

--- a/lib/feature/github_repo/presentation/widgets/repo_tile.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_tile.dart
@@ -61,7 +61,7 @@ class RepoTile extends StatelessWidget {
                     child: Text(repository.stargazersCount.withAlphabet),
                   ),
 
-                /// ふぉ０
+                /// フォーク数
                 const SizedBox(width: 5),
                 if (repository.forksCount != 0)
                   _CustomIcon(

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -3,6 +3,7 @@
     
     "notFound": "Sorry... Not Found",
     "retry" : "Retry",
+    "repository" : "Repository: ",
     "language" : "language",
     "star" : "star",
     "watch" : "watch",
@@ -14,8 +15,8 @@
     "themeTerminate" : "Terminal Settings",
     "themeLightMode" : "Light Mode",
     "themeDarkMode" : "Dark Mode",
-    "error422Network" : "No Internet connection.",
-    "error422Timeout" : "Connection timeout.",
+    "errorNetwork" : "No Internet connection.",
+    "errorTimeout" : "Connection timeout.",
     "error403": "Request Limitations. Please wait for a while.",
     "error422Null" : "Invalid field.",
     "error422Missing" : "The resource does not exist.",

--- a/lib/i18n/strings_ja.i18n.json
+++ b/lib/i18n/strings_ja.i18n.json
@@ -3,6 +3,7 @@
     
     "notFound": "見つかりませんでした。",
     "retry" : "再試行",
+    "repository": "リポジトリ: ",
     "language" : "言語",
     "star" : "スター数",
     "watch" : "ウォッチ数",
@@ -14,8 +15,8 @@
     "themeTerminate" : "端末の設定",
     "themeLightMode" : "ライトモード",
     "themeDarkMode" : "ダークモード",
-    "error422Network" : "インタネットに接続されていません。",
-    "error422Timeout" : "タイムアウトしました。",
+    "errorNetwork" : "インタネットに接続されていません。",
+    "errorTimeout" : "タイムアウトしました。",
     "error403": "リクエスト制限です。しばらくお待ちください。",
     "error422Null" : "無効なフィールドです。",
     "error422Missing" : "リソースが存在しません。",

--- a/lib/i18n/translations.g.dart
+++ b/lib/i18n/translations.g.dart
@@ -1,4 +1,3 @@
-
 /*
  * Generated file. Do not edit.
  *
@@ -18,8 +17,8 @@ AppLocale _currLocale = _baseLocale;
 /// - Locale locale = AppLocale.en.flutterLocale // get flutter locale from enum
 /// - if (LocaleSettings.currentLocale == AppLocale.en) // locale check
 enum AppLocale {
-	en, // 'en' (base locale, fallback)
-	ja, // 'ja'
+  en, // 'en' (base locale, fallback)
+  ja, // 'ja'
 }
 
 /// Method A: Simple
@@ -47,94 +46,92 @@ _TranslationsEn get i18n => _i18n;
 /// final i18n = Translations.of(context); // Get i18n variable.
 /// String a = i18n.someKey.anotherKey; // Use i18n variable.
 class Translations {
-	Translations._(); // no constructor
+  Translations._(); // no constructor
 
-	static _TranslationsEn of(BuildContext context) {
-		final inheritedWidget = context.dependOnInheritedWidgetOfExactType<_InheritedLocaleData>();
-		if (inheritedWidget == null) {
-			throw 'Please wrap your app with "TranslationProvider".';
-		}
-		return inheritedWidget.translations;
-	}
+  static _TranslationsEn of(BuildContext context) {
+    final inheritedWidget =
+        context.dependOnInheritedWidgetOfExactType<_InheritedLocaleData>();
+    if (inheritedWidget == null) {
+      throw 'Please wrap your app with "TranslationProvider".';
+    }
+    return inheritedWidget.translations;
+  }
 }
 
 class LocaleSettings {
-	LocaleSettings._(); // no constructor
+  LocaleSettings._(); // no constructor
 
-	/// Uses locale of the device, fallbacks to base locale.
-	/// Returns the locale which has been set.
-	static AppLocale useDeviceLocale() {
-		final locale = AppLocaleUtils.findDeviceLocale();
-		return setLocale(locale);
-	}
+  /// Uses locale of the device, fallbacks to base locale.
+  /// Returns the locale which has been set.
+  static AppLocale useDeviceLocale() {
+    final locale = AppLocaleUtils.findDeviceLocale();
+    return setLocale(locale);
+  }
 
-	/// Sets locale
-	/// Returns the locale which has been set.
-	static AppLocale setLocale(AppLocale locale) {
-		_currLocale = locale;
-		_i18n = _currLocale.translations;
+  /// Sets locale
+  /// Returns the locale which has been set.
+  static AppLocale setLocale(AppLocale locale) {
+    _currLocale = locale;
+    _i18n = _currLocale.translations;
 
-		// force rebuild if TranslationProvider is used
-		_translationProviderKey.currentState?.setLocale(_currLocale);
+    // force rebuild if TranslationProvider is used
+    _translationProviderKey.currentState?.setLocale(_currLocale);
 
-		return _currLocale;
-	}
+    return _currLocale;
+  }
 
-	/// Sets locale using string tag (e.g. en_US, de-DE, fr)
-	/// Fallbacks to base locale.
-	/// Returns the locale which has been set.
-	static AppLocale setLocaleRaw(String rawLocale) {
-		final locale = AppLocaleUtils.parse(rawLocale);
-		return setLocale(locale);
-	}
+  /// Sets locale using string tag (e.g. en_US, de-DE, fr)
+  /// Fallbacks to base locale.
+  /// Returns the locale which has been set.
+  static AppLocale setLocaleRaw(String rawLocale) {
+    final locale = AppLocaleUtils.parse(rawLocale);
+    return setLocale(locale);
+  }
 
-	/// Gets current locale.
-	static AppLocale get currentLocale {
-		return _currLocale;
-	}
+  /// Gets current locale.
+  static AppLocale get currentLocale {
+    return _currLocale;
+  }
 
-	/// Gets base locale.
-	static AppLocale get baseLocale {
-		return _baseLocale;
-	}
+  /// Gets base locale.
+  static AppLocale get baseLocale {
+    return _baseLocale;
+  }
 
-	/// Gets supported locales in string format.
-	static List<String> get supportedLocalesRaw {
-		return AppLocale.values
-			.map((locale) => locale.languageTag)
-			.toList();
-	}
+  /// Gets supported locales in string format.
+  static List<String> get supportedLocalesRaw {
+    return AppLocale.values.map((locale) => locale.languageTag).toList();
+  }
 
-	/// Gets supported locales (as Locale objects) with base locale sorted first.
-	static List<Locale> get supportedLocales {
-		return AppLocale.values
-			.map((locale) => locale.flutterLocale)
-			.toList();
-	}
+  /// Gets supported locales (as Locale objects) with base locale sorted first.
+  static List<Locale> get supportedLocales {
+    return AppLocale.values.map((locale) => locale.flutterLocale).toList();
+  }
 }
 
 /// Provides utility functions without any side effects.
 class AppLocaleUtils {
-	AppLocaleUtils._(); // no constructor
+  AppLocaleUtils._(); // no constructor
 
-	/// Returns the locale of the device as the enum type.
-	/// Fallbacks to base locale.
-	static AppLocale findDeviceLocale() {
-		final String? deviceLocale = WidgetsBinding.instance.window.locale.toLanguageTag();
-		if (deviceLocale != null) {
-			final typedLocale = _selectLocale(deviceLocale);
-			if (typedLocale != null) {
-				return typedLocale;
-			}
-		}
-		return _baseLocale;
-	}
+  /// Returns the locale of the device as the enum type.
+  /// Fallbacks to base locale.
+  static AppLocale findDeviceLocale() {
+    final String? deviceLocale =
+        WidgetsBinding.instance.window.locale.toLanguageTag();
+    if (deviceLocale != null) {
+      final typedLocale = _selectLocale(deviceLocale);
+      if (typedLocale != null) {
+        return typedLocale;
+      }
+    }
+    return _baseLocale;
+  }
 
-	/// Returns the enum type of the raw locale.
-	/// Fallbacks to base locale.
-	static AppLocale parse(String rawLocale) {
-		return _selectLocale(rawLocale) ?? _baseLocale;
-	}
+  /// Returns the enum type of the raw locale.
+  /// Fallbacks to base locale.
+  static AppLocale parse(String rawLocale) {
+    return _selectLocale(rawLocale) ?? _baseLocale;
+  }
 }
 
 // context enums
@@ -149,221 +146,265 @@ late _TranslationsJa _translationsJa = _TranslationsJa.build();
 // extensions for AppLocale
 
 extension AppLocaleExtensions on AppLocale {
+  /// Gets the translation instance managed by this library.
+  /// [TranslationProvider] is using this instance.
+  /// The plural resolvers are set via [LocaleSettings].
+  _TranslationsEn get translations {
+    switch (this) {
+      case AppLocale.en:
+        return _translationsEn;
+      case AppLocale.ja:
+        return _translationsJa;
+    }
+  }
 
-	/// Gets the translation instance managed by this library.
-	/// [TranslationProvider] is using this instance.
-	/// The plural resolvers are set via [LocaleSettings].
-	_TranslationsEn get translations {
-		switch (this) {
-			case AppLocale.en: return _translationsEn;
-			case AppLocale.ja: return _translationsJa;
-		}
-	}
+  /// Gets a new translation instance.
+  /// [LocaleSettings] has no effect here.
+  /// Suitable for dependency injection and unit tests.
+  ///
+  /// Usage:
+  /// final t = AppLocale.en.build(); // build
+  /// String a = t.my.path; // access
+  _TranslationsEn build() {
+    switch (this) {
+      case AppLocale.en:
+        return _TranslationsEn.build();
+      case AppLocale.ja:
+        return _TranslationsJa.build();
+    }
+  }
 
-	/// Gets a new translation instance.
-	/// [LocaleSettings] has no effect here.
-	/// Suitable for dependency injection and unit tests.
-	///
-	/// Usage:
-	/// final t = AppLocale.en.build(); // build
-	/// String a = t.my.path; // access
-	_TranslationsEn build() {
-		switch (this) {
-			case AppLocale.en: return _TranslationsEn.build();
-			case AppLocale.ja: return _TranslationsJa.build();
-		}
-	}
+  String get languageTag {
+    switch (this) {
+      case AppLocale.en:
+        return 'en';
+      case AppLocale.ja:
+        return 'ja';
+    }
+  }
 
-	String get languageTag {
-		switch (this) {
-			case AppLocale.en: return 'en';
-			case AppLocale.ja: return 'ja';
-		}
-	}
-
-	Locale get flutterLocale {
-		switch (this) {
-			case AppLocale.en: return const Locale.fromSubtags(languageCode: 'en');
-			case AppLocale.ja: return const Locale.fromSubtags(languageCode: 'ja');
-		}
-	}
+  Locale get flutterLocale {
+    switch (this) {
+      case AppLocale.en:
+        return const Locale.fromSubtags(languageCode: 'en');
+      case AppLocale.ja:
+        return const Locale.fromSubtags(languageCode: 'ja');
+    }
+  }
 }
 
 extension StringAppLocaleExtensions on String {
-	AppLocale? toAppLocale() {
-		switch (this) {
-			case 'en': return AppLocale.en;
-			case 'ja': return AppLocale.ja;
-			default: return null;
-		}
-	}
+  AppLocale? toAppLocale() {
+    switch (this) {
+      case 'en':
+        return AppLocale.en;
+      case 'ja':
+        return AppLocale.ja;
+      default:
+        return null;
+    }
+  }
 }
 
 // wrappers
 
-GlobalKey<_TranslationProviderState> _translationProviderKey = GlobalKey<_TranslationProviderState>();
+GlobalKey<_TranslationProviderState> _translationProviderKey =
+    GlobalKey<_TranslationProviderState>();
 
 class TranslationProvider extends StatefulWidget {
-	TranslationProvider({required this.child}) : super(key: _translationProviderKey);
+  TranslationProvider({required this.child})
+      : super(key: _translationProviderKey);
 
-	final Widget child;
+  final Widget child;
 
-	@override
-	_TranslationProviderState createState() => _TranslationProviderState();
+  @override
+  _TranslationProviderState createState() => _TranslationProviderState();
 
-	static _InheritedLocaleData of(BuildContext context) {
-		final inheritedWidget = context.dependOnInheritedWidgetOfExactType<_InheritedLocaleData>();
-		if (inheritedWidget == null) {
-			throw 'Please wrap your app with "TranslationProvider".';
-		}
-		return inheritedWidget;
-	}
+  static _InheritedLocaleData of(BuildContext context) {
+    final inheritedWidget =
+        context.dependOnInheritedWidgetOfExactType<_InheritedLocaleData>();
+    if (inheritedWidget == null) {
+      throw 'Please wrap your app with "TranslationProvider".';
+    }
+    return inheritedWidget;
+  }
 }
 
 class _TranslationProviderState extends State<TranslationProvider> {
-	AppLocale locale = _currLocale;
+  AppLocale locale = _currLocale;
 
-	void setLocale(AppLocale newLocale) {
-		setState(() {
-			locale = newLocale;
-		});
-	}
+  void setLocale(AppLocale newLocale) {
+    setState(() {
+      locale = newLocale;
+    });
+  }
 
-	@override
-	Widget build(BuildContext context) {
-		return _InheritedLocaleData(
-			locale: locale,
-			child: widget.child,
-		);
-	}
+  @override
+  Widget build(BuildContext context) {
+    return _InheritedLocaleData(
+      locale: locale,
+      child: widget.child,
+    );
+  }
 }
 
 class _InheritedLocaleData extends InheritedWidget {
-	final AppLocale locale;
-	Locale get flutterLocale => locale.flutterLocale; // shortcut
-	final _TranslationsEn translations; // store translations to avoid switch call
+  final AppLocale locale;
+  Locale get flutterLocale => locale.flutterLocale; // shortcut
+  final _TranslationsEn translations; // store translations to avoid switch call
 
-	_InheritedLocaleData({required this.locale, required Widget child})
-		: translations = locale.translations, super(child: child);
+  _InheritedLocaleData({required this.locale, required Widget child})
+      : translations = locale.translations,
+        super(child: child);
 
-	@override
-	bool updateShouldNotify(_InheritedLocaleData oldWidget) {
-		return oldWidget.locale != locale;
-	}
+  @override
+  bool updateShouldNotify(_InheritedLocaleData oldWidget) {
+    return oldWidget.locale != locale;
+  }
 }
 
 // pluralization feature not used
 
 // helpers
 
-final _localeRegex = RegExp(r'^([a-z]{2,8})?([_-]([A-Za-z]{4}))?([_-]?([A-Z]{2}|[0-9]{3}))?$');
+final _localeRegex =
+    RegExp(r'^([a-z]{2,8})?([_-]([A-Za-z]{4}))?([_-]?([A-Z]{2}|[0-9]{3}))?$');
 AppLocale? _selectLocale(String localeRaw) {
-	final match = _localeRegex.firstMatch(localeRaw);
-	AppLocale? selected;
-	if (match != null) {
-		final language = match.group(1);
-		final country = match.group(5);
+  final match = _localeRegex.firstMatch(localeRaw);
+  AppLocale? selected;
+  if (match != null) {
+    final language = match.group(1);
+    final country = match.group(5);
 
-		// match exactly
-		selected = AppLocale.values
-			.cast<AppLocale?>()
-			.firstWhere((supported) => supported?.languageTag == localeRaw.replaceAll('_', '-'), orElse: () => null);
+    // match exactly
+    selected = AppLocale.values.cast<AppLocale?>().firstWhere(
+        (supported) => supported?.languageTag == localeRaw.replaceAll('_', '-'),
+        orElse: () => null);
 
-		if (selected == null && language != null) {
-			// match language
-			selected = AppLocale.values
-				.cast<AppLocale?>()
-				.firstWhere((supported) => supported?.languageTag.startsWith(language) == true, orElse: () => null);
-		}
+    if (selected == null && language != null) {
+      // match language
+      selected = AppLocale.values.cast<AppLocale?>().firstWhere(
+          (supported) => supported?.languageTag.startsWith(language) == true,
+          orElse: () => null);
+    }
 
-		if (selected == null && country != null) {
-			// match country
-			selected = AppLocale.values
-				.cast<AppLocale?>()
-				.firstWhere((supported) => supported?.languageTag.contains(country) == true, orElse: () => null);
-		}
-	}
-	return selected;
+    if (selected == null && country != null) {
+      // match country
+      selected = AppLocale.values.cast<AppLocale?>().firstWhere(
+          (supported) => supported?.languageTag.contains(country) == true,
+          orElse: () => null);
+    }
+  }
+  return selected;
 }
 
 // translations
 
 // Path: <root>
 class _TranslationsEn {
+  /// You can call this constructor and build your own translation instance of this locale.
+  /// Constructing via the enum [AppLocale.build] is preferred.
+  _TranslationsEn.build();
 
-	/// You can call this constructor and build your own translation instance of this locale.
-	/// Constructing via the enum [AppLocale.build] is preferred.
-	_TranslationsEn.build();
+  late final _TranslationsEn _root = this; // ignore: unused_field
 
-	late final _TranslationsEn _root = this; // ignore: unused_field
-
-	// Translations
-	String get notFound => 'Sorry... Not Found';
-	String get retry => 'Retry';
-	String get repository => 'Repository: ';
-	String get language => 'language';
-	String get star => 'star';
-	String get watch => 'watch';
-	String get fork => 'fork';
-	String get issue => 'issue';
-	String get search => 'Search Repository';
-	String totalRepo({required Object totalCount}) => 'Total: $totalCount';
-	String get settingTitle => 'Settings';
-	String get themeTerminate => 'Terminal Settings';
-	String get themeLightMode => 'Light Mode';
-	String get themeDarkMode => 'Dark Mode';
-	String get errorNetwork => 'No Internet connection.';
-	String get errorTimeout => 'Connection timeout.';
-	String get error403 => 'Request Limitations. Please wait for a while.';
-	String get error422Null => 'Invalid field.';
-	String get error422Missing => 'The resource does not exist.';
-	String get error422MissingField => 'Required fields have not been filled in.';
-	String get error422Invalid => 'Invalid field format.';
-	String get error422Exists => 'Resource content is duplicated.';
-	String get error422UnProcessable => 'Invalid input.';
-	String get errorDefault => 'Error occurred.';
-	String get validationHasValue => 'Enter the name of the repository.';
-	String validationMaxLength({required Object maxLength}) => 'Please enter up to $maxLength characters.';
-	String get navLabelSearch => 'Search';
-	String get navLabelSettings => 'Settings';
+  // Translations
+  String get notFound => 'Sorry... Not Found';
+  String get retry => 'Retry';
+  String get repository => 'Repository: ';
+  String get language => 'language';
+  String get star => 'star';
+  String get watch => 'watch';
+  String get fork => 'fork';
+  String get issue => 'issue';
+  String get search => 'Search Repository';
+  String totalRepo({required Object totalCount}) => 'Total: $totalCount';
+  String get settingTitle => 'Settings';
+  String get themeTerminate => 'Terminal Settings';
+  String get themeLightMode => 'Light Mode';
+  String get themeDarkMode => 'Dark Mode';
+  String get errorNetwork => 'No Internet connection.';
+  String get errorTimeout => 'Connection timeout.';
+  String get error403 => 'Request Limitations. Please wait for a while.';
+  String get error422Null => 'Invalid field.';
+  String get error422Missing => 'The resource does not exist.';
+  String get error422MissingField => 'Required fields have not been filled in.';
+  String get error422Invalid => 'Invalid field format.';
+  String get error422Exists => 'Resource content is duplicated.';
+  String get error422UnProcessable => 'Invalid input.';
+  String get errorDefault => 'Error occurred.';
+  String get validationHasValue => 'Enter the name of the repository.';
+  String validationMaxLength({required Object maxLength}) =>
+      'Please enter up to $maxLength characters.';
+  String get navLabelSearch => 'Search';
+  String get navLabelSettings => 'Settings';
 }
 
 // Path: <root>
 class _TranslationsJa implements _TranslationsEn {
+  /// You can call this constructor and build your own translation instance of this locale.
+  /// Constructing via the enum [AppLocale.build] is preferred.
+  _TranslationsJa.build();
 
-	/// You can call this constructor and build your own translation instance of this locale.
-	/// Constructing via the enum [AppLocale.build] is preferred.
-	_TranslationsJa.build();
+  @override
+  late final _TranslationsJa _root = this; // ignore: unused_field
 
-	@override late final _TranslationsJa _root = this; // ignore: unused_field
-
-	// Translations
-	@override String get notFound => '見つかりませんでした。';
-	@override String get retry => '再試行';
-	@override String get repository => 'リポジトリ: ';
-	@override String get language => '言語';
-	@override String get star => 'スター数';
-	@override String get watch => 'ウォッチ数';
-	@override String get fork => 'フォーク数';
-	@override String get issue => 'イシュー数';
-	@override String get search => 'レポジトリを検索';
-	@override String totalRepo({required Object totalCount}) => '合計$totalCount件';
-	@override String get settingTitle => '設定';
-	@override String get themeTerminate => '端末の設定';
-	@override String get themeLightMode => 'ライトモード';
-	@override String get themeDarkMode => 'ダークモード';
-	@override String get errorNetwork => 'インタネットに接続されていません。';
-	@override String get errorTimeout => 'タイムアウトしました。';
-	@override String get error403 => 'リクエスト制限です。しばらくお待ちください。';
-	@override String get error422Null => '無効なフィールドです。';
-	@override String get error422Missing => 'リソースが存在しません。';
-	@override String get error422MissingField => '必須リソースが存在しません。';
-	@override String get error422Invalid => '無効なフォーマットです。';
-	@override String get error422Exists => '重複したリソースがあります。';
-	@override String get error422UnProcessable => '無効な入力です。';
-	@override String get errorDefault => 'エラーが発生しました。';
-	@override String get validationHasValue => 'リポジトリ名を入力してください。';
-	@override String validationMaxLength({required Object maxLength}) => '$maxLength 文字以内で入力してください。';
-	@override String get navLabelSearch => '検索';
-	@override String get navLabelSettings => '設定';
+  // Translations
+  @override
+  String get notFound => '見つかりませんでした。';
+  @override
+  String get retry => '再試行';
+  @override
+  String get repository => 'リポジトリ: ';
+  @override
+  String get language => '言語';
+  @override
+  String get star => 'スター数';
+  @override
+  String get watch => 'ウォッチ数';
+  @override
+  String get fork => 'フォーク数';
+  @override
+  String get issue => 'イシュー数';
+  @override
+  String get search => 'レポジトリを検索';
+  @override
+  String totalRepo({required Object totalCount}) => '合計$totalCount件';
+  @override
+  String get settingTitle => '設定';
+  @override
+  String get themeTerminate => '端末の設定';
+  @override
+  String get themeLightMode => 'ライトモード';
+  @override
+  String get themeDarkMode => 'ダークモード';
+  @override
+  String get errorNetwork => 'インタネットに接続されていません。';
+  @override
+  String get errorTimeout => 'タイムアウトしました。';
+  @override
+  String get error403 => 'リクエスト制限です。しばらくお待ちください。';
+  @override
+  String get error422Null => '無効なフィールドです。';
+  @override
+  String get error422Missing => 'リソースが存在しません。';
+  @override
+  String get error422MissingField => '必須リソースが存在しません。';
+  @override
+  String get error422Invalid => '無効なフォーマットです。';
+  @override
+  String get error422Exists => '重複したリソースがあります。';
+  @override
+  String get error422UnProcessable => '無効な入力です。';
+  @override
+  String get errorDefault => 'エラーが発生しました。';
+  @override
+  String get validationHasValue => 'リポジトリ名を入力してください。';
+  @override
+  String validationMaxLength({required Object maxLength}) =>
+      '$maxLength 文字以内で入力してください。';
+  @override
+  String get navLabelSearch => '検索';
+  @override
+  String get navLabelSettings => '設定';
 }

--- a/lib/i18n/translations.g.dart
+++ b/lib/i18n/translations.g.dart
@@ -1,8 +1,9 @@
+
 /*
  * Generated file. Do not edit.
  *
  * Locales: 2
- * Strings: 54 (27.0 per locale)
+ * Strings: 56 (28.0 per locale)
  */
 
 import 'package:flutter/widgets.dart';
@@ -17,8 +18,8 @@ AppLocale _currLocale = _baseLocale;
 /// - Locale locale = AppLocale.en.flutterLocale // get flutter locale from enum
 /// - if (LocaleSettings.currentLocale == AppLocale.en) // locale check
 enum AppLocale {
-  en, // 'en' (base locale, fallback)
-  ja, // 'ja'
+	en, // 'en' (base locale, fallback)
+	ja, // 'ja'
 }
 
 /// Method A: Simple
@@ -46,92 +47,94 @@ _TranslationsEn get i18n => _i18n;
 /// final i18n = Translations.of(context); // Get i18n variable.
 /// String a = i18n.someKey.anotherKey; // Use i18n variable.
 class Translations {
-  Translations._(); // no constructor
+	Translations._(); // no constructor
 
-  static _TranslationsEn of(BuildContext context) {
-    final inheritedWidget =
-        context.dependOnInheritedWidgetOfExactType<_InheritedLocaleData>();
-    if (inheritedWidget == null) {
-      throw 'Please wrap your app with "TranslationProvider".';
-    }
-    return inheritedWidget.translations;
-  }
+	static _TranslationsEn of(BuildContext context) {
+		final inheritedWidget = context.dependOnInheritedWidgetOfExactType<_InheritedLocaleData>();
+		if (inheritedWidget == null) {
+			throw 'Please wrap your app with "TranslationProvider".';
+		}
+		return inheritedWidget.translations;
+	}
 }
 
 class LocaleSettings {
-  LocaleSettings._(); // no constructor
+	LocaleSettings._(); // no constructor
 
-  /// Uses locale of the device, fallbacks to base locale.
-  /// Returns the locale which has been set.
-  static AppLocale useDeviceLocale() {
-    final locale = AppLocaleUtils.findDeviceLocale();
-    return setLocale(locale);
-  }
+	/// Uses locale of the device, fallbacks to base locale.
+	/// Returns the locale which has been set.
+	static AppLocale useDeviceLocale() {
+		final locale = AppLocaleUtils.findDeviceLocale();
+		return setLocale(locale);
+	}
 
-  /// Sets locale
-  /// Returns the locale which has been set.
-  static AppLocale setLocale(AppLocale locale) {
-    _currLocale = locale;
-    _i18n = _currLocale.translations;
+	/// Sets locale
+	/// Returns the locale which has been set.
+	static AppLocale setLocale(AppLocale locale) {
+		_currLocale = locale;
+		_i18n = _currLocale.translations;
 
-    // force rebuild if TranslationProvider is used
-    _translationProviderKey.currentState?.setLocale(_currLocale);
+		// force rebuild if TranslationProvider is used
+		_translationProviderKey.currentState?.setLocale(_currLocale);
 
-    return _currLocale;
-  }
+		return _currLocale;
+	}
 
-  /// Sets locale using string tag (e.g. en_US, de-DE, fr)
-  /// Fallbacks to base locale.
-  /// Returns the locale which has been set.
-  static AppLocale setLocaleRaw(String rawLocale) {
-    final locale = AppLocaleUtils.parse(rawLocale);
-    return setLocale(locale);
-  }
+	/// Sets locale using string tag (e.g. en_US, de-DE, fr)
+	/// Fallbacks to base locale.
+	/// Returns the locale which has been set.
+	static AppLocale setLocaleRaw(String rawLocale) {
+		final locale = AppLocaleUtils.parse(rawLocale);
+		return setLocale(locale);
+	}
 
-  /// Gets current locale.
-  static AppLocale get currentLocale {
-    return _currLocale;
-  }
+	/// Gets current locale.
+	static AppLocale get currentLocale {
+		return _currLocale;
+	}
 
-  /// Gets base locale.
-  static AppLocale get baseLocale {
-    return _baseLocale;
-  }
+	/// Gets base locale.
+	static AppLocale get baseLocale {
+		return _baseLocale;
+	}
 
-  /// Gets supported locales in string format.
-  static List<String> get supportedLocalesRaw {
-    return AppLocale.values.map((locale) => locale.languageTag).toList();
-  }
+	/// Gets supported locales in string format.
+	static List<String> get supportedLocalesRaw {
+		return AppLocale.values
+			.map((locale) => locale.languageTag)
+			.toList();
+	}
 
-  /// Gets supported locales (as Locale objects) with base locale sorted first.
-  static List<Locale> get supportedLocales {
-    return AppLocale.values.map((locale) => locale.flutterLocale).toList();
-  }
+	/// Gets supported locales (as Locale objects) with base locale sorted first.
+	static List<Locale> get supportedLocales {
+		return AppLocale.values
+			.map((locale) => locale.flutterLocale)
+			.toList();
+	}
 }
 
 /// Provides utility functions without any side effects.
 class AppLocaleUtils {
-  AppLocaleUtils._(); // no constructor
+	AppLocaleUtils._(); // no constructor
 
-  /// Returns the locale of the device as the enum type.
-  /// Fallbacks to base locale.
-  static AppLocale findDeviceLocale() {
-    final String? deviceLocale =
-        WidgetsBinding.instance.window.locale.toLanguageTag();
-    if (deviceLocale != null) {
-      final typedLocale = _selectLocale(deviceLocale);
-      if (typedLocale != null) {
-        return typedLocale;
-      }
-    }
-    return _baseLocale;
-  }
+	/// Returns the locale of the device as the enum type.
+	/// Fallbacks to base locale.
+	static AppLocale findDeviceLocale() {
+		final String? deviceLocale = WidgetsBinding.instance.window.locale.toLanguageTag();
+		if (deviceLocale != null) {
+			final typedLocale = _selectLocale(deviceLocale);
+			if (typedLocale != null) {
+				return typedLocale;
+			}
+		}
+		return _baseLocale;
+	}
 
-  /// Returns the enum type of the raw locale.
-  /// Fallbacks to base locale.
-  static AppLocale parse(String rawLocale) {
-    return _selectLocale(rawLocale) ?? _baseLocale;
-  }
+	/// Returns the enum type of the raw locale.
+	/// Fallbacks to base locale.
+	static AppLocale parse(String rawLocale) {
+		return _selectLocale(rawLocale) ?? _baseLocale;
+	}
 }
 
 // context enums
@@ -146,262 +149,221 @@ late _TranslationsJa _translationsJa = _TranslationsJa.build();
 // extensions for AppLocale
 
 extension AppLocaleExtensions on AppLocale {
-  /// Gets the translation instance managed by this library.
-  /// [TranslationProvider] is using this instance.
-  /// The plural resolvers are set via [LocaleSettings].
-  _TranslationsEn get translations {
-    switch (this) {
-      case AppLocale.en:
-        return _translationsEn;
-      case AppLocale.ja:
-        return _translationsJa;
-    }
-  }
 
-  /// Gets a new translation instance.
-  /// [LocaleSettings] has no effect here.
-  /// Suitable for dependency injection and unit tests.
-  ///
-  /// Usage:
-  /// final t = AppLocale.en.build(); // build
-  /// String a = t.my.path; // access
-  _TranslationsEn build() {
-    switch (this) {
-      case AppLocale.en:
-        return _TranslationsEn.build();
-      case AppLocale.ja:
-        return _TranslationsJa.build();
-    }
-  }
+	/// Gets the translation instance managed by this library.
+	/// [TranslationProvider] is using this instance.
+	/// The plural resolvers are set via [LocaleSettings].
+	_TranslationsEn get translations {
+		switch (this) {
+			case AppLocale.en: return _translationsEn;
+			case AppLocale.ja: return _translationsJa;
+		}
+	}
 
-  String get languageTag {
-    switch (this) {
-      case AppLocale.en:
-        return 'en';
-      case AppLocale.ja:
-        return 'ja';
-    }
-  }
+	/// Gets a new translation instance.
+	/// [LocaleSettings] has no effect here.
+	/// Suitable for dependency injection and unit tests.
+	///
+	/// Usage:
+	/// final t = AppLocale.en.build(); // build
+	/// String a = t.my.path; // access
+	_TranslationsEn build() {
+		switch (this) {
+			case AppLocale.en: return _TranslationsEn.build();
+			case AppLocale.ja: return _TranslationsJa.build();
+		}
+	}
 
-  Locale get flutterLocale {
-    switch (this) {
-      case AppLocale.en:
-        return const Locale.fromSubtags(languageCode: 'en');
-      case AppLocale.ja:
-        return const Locale.fromSubtags(languageCode: 'ja');
-    }
-  }
+	String get languageTag {
+		switch (this) {
+			case AppLocale.en: return 'en';
+			case AppLocale.ja: return 'ja';
+		}
+	}
+
+	Locale get flutterLocale {
+		switch (this) {
+			case AppLocale.en: return const Locale.fromSubtags(languageCode: 'en');
+			case AppLocale.ja: return const Locale.fromSubtags(languageCode: 'ja');
+		}
+	}
 }
 
 extension StringAppLocaleExtensions on String {
-  AppLocale? toAppLocale() {
-    switch (this) {
-      case 'en':
-        return AppLocale.en;
-      case 'ja':
-        return AppLocale.ja;
-      default:
-        return null;
-    }
-  }
+	AppLocale? toAppLocale() {
+		switch (this) {
+			case 'en': return AppLocale.en;
+			case 'ja': return AppLocale.ja;
+			default: return null;
+		}
+	}
 }
 
 // wrappers
 
-GlobalKey<_TranslationProviderState> _translationProviderKey =
-    GlobalKey<_TranslationProviderState>();
+GlobalKey<_TranslationProviderState> _translationProviderKey = GlobalKey<_TranslationProviderState>();
 
 class TranslationProvider extends StatefulWidget {
-  TranslationProvider({required this.child})
-      : super(key: _translationProviderKey);
+	TranslationProvider({required this.child}) : super(key: _translationProviderKey);
 
-  final Widget child;
+	final Widget child;
 
-  @override
-  _TranslationProviderState createState() => _TranslationProviderState();
+	@override
+	_TranslationProviderState createState() => _TranslationProviderState();
 
-  static _InheritedLocaleData of(BuildContext context) {
-    final inheritedWidget =
-        context.dependOnInheritedWidgetOfExactType<_InheritedLocaleData>();
-    if (inheritedWidget == null) {
-      throw 'Please wrap your app with "TranslationProvider".';
-    }
-    return inheritedWidget;
-  }
+	static _InheritedLocaleData of(BuildContext context) {
+		final inheritedWidget = context.dependOnInheritedWidgetOfExactType<_InheritedLocaleData>();
+		if (inheritedWidget == null) {
+			throw 'Please wrap your app with "TranslationProvider".';
+		}
+		return inheritedWidget;
+	}
 }
 
 class _TranslationProviderState extends State<TranslationProvider> {
-  AppLocale locale = _currLocale;
+	AppLocale locale = _currLocale;
 
-  void setLocale(AppLocale newLocale) {
-    setState(() {
-      locale = newLocale;
-    });
-  }
+	void setLocale(AppLocale newLocale) {
+		setState(() {
+			locale = newLocale;
+		});
+	}
 
-  @override
-  Widget build(BuildContext context) {
-    return _InheritedLocaleData(
-      locale: locale,
-      child: widget.child,
-    );
-  }
+	@override
+	Widget build(BuildContext context) {
+		return _InheritedLocaleData(
+			locale: locale,
+			child: widget.child,
+		);
+	}
 }
 
 class _InheritedLocaleData extends InheritedWidget {
-  final AppLocale locale;
-  Locale get flutterLocale => locale.flutterLocale; // shortcut
-  final _TranslationsEn translations; // store translations to avoid switch call
+	final AppLocale locale;
+	Locale get flutterLocale => locale.flutterLocale; // shortcut
+	final _TranslationsEn translations; // store translations to avoid switch call
 
-  _InheritedLocaleData({required this.locale, required Widget child})
-      : translations = locale.translations,
-        super(child: child);
+	_InheritedLocaleData({required this.locale, required Widget child})
+		: translations = locale.translations, super(child: child);
 
-  @override
-  bool updateShouldNotify(_InheritedLocaleData oldWidget) {
-    return oldWidget.locale != locale;
-  }
+	@override
+	bool updateShouldNotify(_InheritedLocaleData oldWidget) {
+		return oldWidget.locale != locale;
+	}
 }
 
 // pluralization feature not used
 
 // helpers
 
-final _localeRegex =
-    RegExp(r'^([a-z]{2,8})?([_-]([A-Za-z]{4}))?([_-]?([A-Z]{2}|[0-9]{3}))?$');
+final _localeRegex = RegExp(r'^([a-z]{2,8})?([_-]([A-Za-z]{4}))?([_-]?([A-Z]{2}|[0-9]{3}))?$');
 AppLocale? _selectLocale(String localeRaw) {
-  final match = _localeRegex.firstMatch(localeRaw);
-  AppLocale? selected;
-  if (match != null) {
-    final language = match.group(1);
-    final country = match.group(5);
+	final match = _localeRegex.firstMatch(localeRaw);
+	AppLocale? selected;
+	if (match != null) {
+		final language = match.group(1);
+		final country = match.group(5);
 
-    // match exactly
-    selected = AppLocale.values.cast<AppLocale?>().firstWhere(
-        (supported) => supported?.languageTag == localeRaw.replaceAll('_', '-'),
-        orElse: () => null);
+		// match exactly
+		selected = AppLocale.values
+			.cast<AppLocale?>()
+			.firstWhere((supported) => supported?.languageTag == localeRaw.replaceAll('_', '-'), orElse: () => null);
 
-    if (selected == null && language != null) {
-      // match language
-      selected = AppLocale.values.cast<AppLocale?>().firstWhere(
-          (supported) => supported?.languageTag.startsWith(language) == true,
-          orElse: () => null);
-    }
+		if (selected == null && language != null) {
+			// match language
+			selected = AppLocale.values
+				.cast<AppLocale?>()
+				.firstWhere((supported) => supported?.languageTag.startsWith(language) == true, orElse: () => null);
+		}
 
-    if (selected == null && country != null) {
-      // match country
-      selected = AppLocale.values.cast<AppLocale?>().firstWhere(
-          (supported) => supported?.languageTag.contains(country) == true,
-          orElse: () => null);
-    }
-  }
-  return selected;
+		if (selected == null && country != null) {
+			// match country
+			selected = AppLocale.values
+				.cast<AppLocale?>()
+				.firstWhere((supported) => supported?.languageTag.contains(country) == true, orElse: () => null);
+		}
+	}
+	return selected;
 }
 
 // translations
 
 // Path: <root>
 class _TranslationsEn {
-  /// You can call this constructor and build your own translation instance of this locale.
-  /// Constructing via the enum [AppLocale.build] is preferred.
-  _TranslationsEn.build();
 
-  late final _TranslationsEn _root = this; // ignore: unused_field
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	_TranslationsEn.build();
 
-  // Translations
-  String get notFound => 'Sorry... Not Found';
-  String get retry => 'Retry';
-  String get language => 'language';
-  String get star => 'star';
-  String get watch => 'watch';
-  String get fork => 'fork';
-  String get issue => 'issue';
-  String get search => 'Search Repository';
-  String totalRepo({required Object totalCount}) => 'Total: $totalCount';
-  String get settingTitle => 'Settings';
-  String get themeTerminate => 'Terminal Settings';
-  String get themeLightMode => 'Light Mode';
-  String get themeDarkMode => 'Dark Mode';
-  String get error422Network => 'No Internet connection.';
-  String get error422Timeout => 'Connection timeout.';
-  String get error403 => 'Request Limitations. Please wait for a while.';
-  String get error422Null => 'Invalid field.';
-  String get error422Missing => 'The resource does not exist.';
-  String get error422MissingField => 'Required fields have not been filled in.';
-  String get error422Invalid => 'Invalid field format.';
-  String get error422Exists => 'Resource content is duplicated.';
-  String get error422UnProcessable => 'Invalid input.';
-  String get errorDefault => 'Error occurred.';
-  String get validationHasValue => 'Enter the name of the repository.';
-  String validationMaxLength({required Object maxLength}) =>
-      'Please enter up to $maxLength characters.';
-  String get navLabelSearch => 'Search';
-  String get navLabelSettings => 'Settings';
+	late final _TranslationsEn _root = this; // ignore: unused_field
+
+	// Translations
+	String get notFound => 'Sorry... Not Found';
+	String get retry => 'Retry';
+	String get repository => 'Repository: ';
+	String get language => 'language';
+	String get star => 'star';
+	String get watch => 'watch';
+	String get fork => 'fork';
+	String get issue => 'issue';
+	String get search => 'Search Repository';
+	String totalRepo({required Object totalCount}) => 'Total: $totalCount';
+	String get settingTitle => 'Settings';
+	String get themeTerminate => 'Terminal Settings';
+	String get themeLightMode => 'Light Mode';
+	String get themeDarkMode => 'Dark Mode';
+	String get errorNetwork => 'No Internet connection.';
+	String get errorTimeout => 'Connection timeout.';
+	String get error403 => 'Request Limitations. Please wait for a while.';
+	String get error422Null => 'Invalid field.';
+	String get error422Missing => 'The resource does not exist.';
+	String get error422MissingField => 'Required fields have not been filled in.';
+	String get error422Invalid => 'Invalid field format.';
+	String get error422Exists => 'Resource content is duplicated.';
+	String get error422UnProcessable => 'Invalid input.';
+	String get errorDefault => 'Error occurred.';
+	String get validationHasValue => 'Enter the name of the repository.';
+	String validationMaxLength({required Object maxLength}) => 'Please enter up to $maxLength characters.';
+	String get navLabelSearch => 'Search';
+	String get navLabelSettings => 'Settings';
 }
 
 // Path: <root>
 class _TranslationsJa implements _TranslationsEn {
-  /// You can call this constructor and build your own translation instance of this locale.
-  /// Constructing via the enum [AppLocale.build] is preferred.
-  _TranslationsJa.build();
 
-  @override
-  late final _TranslationsJa _root = this; // ignore: unused_field
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	_TranslationsJa.build();
 
-  // Translations
-  @override
-  String get notFound => '見つかりませんでした。';
-  @override
-  String get retry => '再試行';
-  @override
-  String get language => '言語';
-  @override
-  String get star => 'スター数';
-  @override
-  String get watch => 'ウォッチ数';
-  @override
-  String get fork => 'フォーク数';
-  @override
-  String get issue => 'イシュー数';
-  @override
-  String get search => 'レポジトリを検索';
-  @override
-  String totalRepo({required Object totalCount}) => '合計$totalCount件';
-  @override
-  String get settingTitle => '設定';
-  @override
-  String get themeTerminate => '端末の設定';
-  @override
-  String get themeLightMode => 'ライトモード';
-  @override
-  String get themeDarkMode => 'ダークモード';
-  @override
-  String get error422Network => 'インタネットに接続されていません。';
-  @override
-  String get error422Timeout => 'タイムアウトしました。';
-  @override
-  String get error403 => 'リクエスト制限です。しばらくお待ちください。';
-  @override
-  String get error422Null => '無効なフィールドです。';
-  @override
-  String get error422Missing => 'リソースが存在しません。';
-  @override
-  String get error422MissingField => '必須リソースが存在しません。';
-  @override
-  String get error422Invalid => '無効なフォーマットです。';
-  @override
-  String get error422Exists => '重複したリソースがあります。';
-  @override
-  String get error422UnProcessable => '無効な入力です。';
-  @override
-  String get errorDefault => 'エラーが発生しました。';
-  @override
-  String get validationHasValue => 'リポジトリ名を入力してください。';
-  @override
-  String validationMaxLength({required Object maxLength}) =>
-      '$maxLength 文字以内で入力してください。';
-  @override
-  String get navLabelSearch => '検索';
-  @override
-  String get navLabelSettings => '設定';
+	@override late final _TranslationsJa _root = this; // ignore: unused_field
+
+	// Translations
+	@override String get notFound => '見つかりませんでした。';
+	@override String get retry => '再試行';
+	@override String get repository => 'リポジトリ: ';
+	@override String get language => '言語';
+	@override String get star => 'スター数';
+	@override String get watch => 'ウォッチ数';
+	@override String get fork => 'フォーク数';
+	@override String get issue => 'イシュー数';
+	@override String get search => 'レポジトリを検索';
+	@override String totalRepo({required Object totalCount}) => '合計$totalCount件';
+	@override String get settingTitle => '設定';
+	@override String get themeTerminate => '端末の設定';
+	@override String get themeLightMode => 'ライトモード';
+	@override String get themeDarkMode => 'ダークモード';
+	@override String get errorNetwork => 'インタネットに接続されていません。';
+	@override String get errorTimeout => 'タイムアウトしました。';
+	@override String get error403 => 'リクエスト制限です。しばらくお待ちください。';
+	@override String get error422Null => '無効なフィールドです。';
+	@override String get error422Missing => 'リソースが存在しません。';
+	@override String get error422MissingField => '必須リソースが存在しません。';
+	@override String get error422Invalid => '無効なフォーマットです。';
+	@override String get error422Exists => '重複したリソースがあります。';
+	@override String get error422UnProcessable => '無効な入力です。';
+	@override String get errorDefault => 'エラーが発生しました。';
+	@override String get validationHasValue => 'リポジトリ名を入力してください。';
+	@override String validationMaxLength({required Object maxLength}) => '$maxLength 文字以内で入力してください。';
+	@override String get navLabelSearch => '検索';
+	@override String get navLabelSettings => '設定';
 }


### PR DESCRIPTION
### おしゃれを目指して
- オーナーアイコンを拡大し、中央に持ってきました。
- Star数などをグリッドスタイルに変更しました。

### 使い勝手を向上するために
- 長文のdescription(概要)に対応するため、概要欄をスクロール可能にしました。
- 横画面になった際にスクロール量を減らすためにグリッドタイルを1行にしました。

|縦画面|横画面|
| --- | --- |
|<img src='https://user-images.githubusercontent.com/89247188/188910392-f02cdac6-27c1-45d2-bf61-af1664c7e97e.gif' width = '300'>|<img src='https://user-images.githubusercontent.com/89247188/188910612-4419659b-3e78-4844-8f10-644f5ed66a56.gif' width = '400'>|

