### PR TITLE
キーボードとダイアログの衝突を回避

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ flutter run --debug
 |:---:|:---:|
 <img src ='https://user-images.githubusercontent.com/89247188/189344255-4964de48-ef5d-48f4-ba55-66ceb045c3fd.png' width = '300'>|<img src ='https://user-images.githubusercontent.com/89247188/189128836-72058c3e-9cbc-442a-b39c-bc97c27572bc.PNG' width = '300'>|
 
+### ソートモード選択
+
+|iOS|Android|
+|:---:|:---:|
+<img src ='https://user-images.githubusercontent.com/89247188/189883816-44a4fe1f-b725-4dd0-8b3f-284cdf056d7b.PNG' width = '300'>|<img src ='https://user-images.githubusercontent.com/89247188/189884162-a5f49759-784d-47bc-b5f3-e1ecfb0c7cdb.png' width = '300'>|
+
+
 ### その他
 
 |検索結果が0件|初回エラー画面|設定画面|

--- a/lib/feature/github_repo/sort_option/sort_option_button.dart
+++ b/lib/feature/github_repo/sort_option/sort_option_button.dart
@@ -1,6 +1,8 @@
 import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
+import 'package:github_repo_search/core/extension/context_extension.dart';
 import 'package:github_repo_search/feature/github_repo/sort_option/sort_option.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
 
@@ -9,26 +11,97 @@ class SortOptionButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    /// 現在のソートオプション
     final sortOption = ref.watch(sortOptionProvider);
     final sortOptionController = ref.watch(sortOptionProvider.state);
     return IconButton(
       icon: const Icon(Icons.sort),
       onPressed: () async {
-        final result = await showConfirmationDialog<SortOption>(
-          context: context,
-          title: i18n.sort,
-          actions: [
-            ...SortOption.values
-                .map(
-                  (sort) => AlertDialogAction(
-                    label: sort.label,
-                    key: sort,
-                  ),
-                )
-                .toList()
-          ],
-          initialSelectedActionKey: sortOption,
-        );
+        final result = context.isIOS
+            // iOS
+            ? await showConfirmationDialog<SortOption>(
+                context: context,
+                title: i18n.sort,
+                actions: [
+                  ...SortOption.values
+                      .map(
+                        (sort) => AlertDialogAction(
+                          label: sort.label,
+                          key: sort,
+                        ),
+                      )
+                      .toList()
+                ],
+                initialSelectedActionKey: sortOption,
+              )
+            // Android
+            : await showModalBottomSheet<SortOption>(
+                backgroundColor: context.scaffoldBackgroundColor,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                context: context,
+                builder: (context) {
+                  SortOption? selectedOption = sortOption;
+
+                  // リストでオプションリストを定義
+                  final optionList = SortOption.values
+                      .map(
+                        (sort) => AlertDialogAction(
+                          label: sort.label,
+                          key: sort,
+                        ),
+                      )
+                      .toList();
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      ListTile(
+                        title: Text(
+                          i18n.sort,
+                          textAlign: TextAlign.start,
+                          style: context.subTitleStyle,
+                        ),
+                      ),
+                      Expanded(
+                        child: ListView.builder(
+                          itemBuilder: (context, index) {
+                            // 現在地のソートオプションはアイコンでわかりやすく
+                            final optionTile =
+                                optionList[index].label == sortOption.label
+                                    ? Row(
+                                        children: [
+                                          Text(
+                                            optionList[index].label,
+                                            style: context.bodyStyle,
+                                          ),
+                                          const Gap(5),
+                                          Icon(
+                                            Icons.check,
+                                            color: context.bodyStyle.color,
+                                          ),
+                                        ],
+                                      )
+                                    : Text(optionList[index].label);
+                            return ListTile(
+                              title: optionTile,
+                              onTap: () {
+                                if (optionList[index].key != sortOption) {
+                                  selectedOption = optionList[index].key;
+                                } else {
+                                  selectedOption = null;
+                                }
+                                Navigator.of(context).pop(selectedOption);
+                              },
+                            );
+                          },
+                          itemCount: optionList.length,
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              );
 
         /// ソートオプションが変更された場合プロバイダーを更新
         if (result != null) {


### PR DESCRIPTION
`context.isIOS`でプラットフォームごとに異なるメソッドを呼ぶ

iOS: showConfirmationDialog
Android:showModalBottomSheet

### キーボードとダイアログの衝突を回避

https://user-images.githubusercontent.com/89247188/189883230-430f8721-2b0c-4649-ba3e-46ed0687e273.mp4




