### PR TITLE
Feat/#issue55/add test flow to GitHub actions

### DIFF
--- a/.github/workflows/flutter_analyze.yaml
+++ b/.github/workflows/flutter_analyze.yaml
@@ -29,4 +29,21 @@ jobs:
         run: flutter pub get
       - name: flutter analyze
         run: flutter analyze
+  flutter_test:
+    name: flutter_test
+    runs-on: ubuntu-latest
+    steps:
+      - name: set up repository
+        uses: actions/checkout@v3
+      - name: set up flutter
+        uses: subosito/flutter-action@v2.6.1
+        with:
+          channel: "stable"
+          cache: false
+      - name: flutter doctor
+        run: flutter doctor -v
+      - name: flutter pub get
+        run: flutter pub get
+      - name: unit test
+        run: flutter test test/
         

--- a/test/core/model/github_repos_state_test.dart
+++ b/test/core/model/github_repos_state_test.dart
@@ -125,25 +125,46 @@ void main() {
     final totalCount = result.totalCount;
     final repositories = result.items;
 
+    expect(totalCount == 0, false);
     expect(totalCount, 1);
 
     // 実際に取得するデータのみを抜粋してテスト
+    expect(repositories[0].id == 0, false);
     expect(repositories[0].id, 3081286);
+
+    expect(repositories[0].name == '', false);
     expect(repositories[0].name, 'Tetris');
+
+    expect(repositories[0].fullName == '', false);
     expect(repositories[0].fullName, 'dtrupenn/Tetris');
+
+    expect(repositories[0].owner.login == '', false);
     expect(repositories[0].owner.login, 'dtrupenn');
+
+    expect(repositories[0].owner.avatarUrl == '', false);
     expect(
       repositories[0].owner.avatarUrl,
       'https://avatars.githubusercontent.com/u/872147?v=4',
     );
+
+    expect(repositories[0].description == '', false);
     expect(
       repositories[0].description,
       'A C implementation of Tetris using Pennsim through LC4',
     );
+    expect(repositories[0].stargazersCount == 0, false);
     expect(repositories[0].stargazersCount, 6);
+
+    expect(repositories[0].watchersCount == 0, false);
     expect(repositories[0].watchersCount, 6);
+
+    expect(repositories[0].language == '', false);
     expect(repositories[0].language, 'Assembly');
+
+    expect(repositories[0].forksCount == 0, false);
     expect(repositories[0].forksCount, 2);
+
+    expect(repositories[0].openIssuesCount == 1, false);
     expect(repositories[0].openIssuesCount, 0);
   });
 }


### PR DESCRIPTION
- GitHubアクションにテストフローを追加
- テストの失敗ケースを追加

そもそもテストを書けていないので、テストが組みやすい設計を学ぶ