### PR TITLE
totalCountの更新ロジックを変更

### DIFF
--- a/lib/feature/github_repo/presentation/widgets/repo_list.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.dart
@@ -5,7 +5,6 @@ import 'package:github_repo_search/core/widgets/retry_button.dart';
 import 'package:github_repo_search/feature/github_repo/pagination/pagination_notifier.dart';
 import 'package:github_repo_search/feature/github_repo/presentation/widgets/not_found.dart';
 import 'package:github_repo_search/feature/github_repo/presentation/widgets/repo_list.builder.dart';
-import 'package:github_repo_search/feature/github_repo/presentation/widgets/total_count_bar.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
 
 class RepoList extends ConsumerWidget {
@@ -18,12 +17,6 @@ class RepoList extends ConsumerWidget {
     return Expanded(
       child: page.when(
         data: (data) {
-          WidgetsBinding.instance.addPostFrameCallback(
-            /// トータルカウントプロバイダーを更新
-            (_) => ref
-                .watch(totalCountProvider.state)
-                .update((state) => data.totalCount),
-          );
           return data.items.isEmpty
               ? const NotFound()
               : RepoListBuilder(
@@ -36,10 +29,6 @@ class RepoList extends ConsumerWidget {
           child: CircularProgressIndicator(),
         ),
         error: (error, stack) {
-          /// トータルカウントプロバイダーを更新(表示させない)
-          WidgetsBinding.instance.addPostFrameCallback(
-            (_) => ref.watch(totalCountProvider.state).update((state) => null),
-          );
           return RetryButton(
             title: error.toString(),
             textButton: ElevatedButton(

--- a/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
+++ b/lib/feature/github_repo/presentation/widgets/total_count_bar.dart
@@ -1,10 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_repo_search/core/extension/num_extension.dart';
+import 'package:github_repo_search/feature/github_repo/pagination/pagination_notifier.dart';
 import 'package:github_repo_search/i18n/translations.g.dart';
 
-/// トータルカウントプロバイダー
-final totalCountProvider = StateProvider<int?>((_) => null);
+/// レポジトリ合計数プロバイダー
+
+// pageProviderからの取得データによって更新
+// 初回エラー、初回ローディング時はnullを返却
+// ページング中エラー、ページング中ローディング時は前回値を返却
+final totalCountProvider = StateProvider<int?>((ref) {
+  final totalCount = ref.watch(pageProvider).whenOrNull(
+        data: (data) => data.totalCount,
+        // 前回値を渡す
+        onGoingError: (previousData, e, stk) => previousData.totalCount,
+        // 前回値を渡す
+        onGoingLoading: (previousData) => previousData.totalCount,
+      );
+
+  return totalCount;
+});
 
 class TotalCountBar extends ConsumerWidget {
   const TotalCountBar({super.key});
@@ -15,8 +30,8 @@ class TotalCountBar extends ConsumerWidget {
     return SizedBox(
       width: double.infinity,
       child: Align(
-        /// null(エラー時)は何も表示しない
         alignment: Alignment.centerRight,
+        // エラー時にはnullが渡る(表示しない)
         child: totalCount != null
             ? Text(i18n.totalRepo(totalCount: totalCount.formatComma))
             : null,

--- a/lib/feature/github_repo/sort_option/sort_option_button.dart
+++ b/lib/feature/github_repo/sort_option/sort_option_button.dart
@@ -66,7 +66,7 @@ class SortOptionButton extends ConsumerWidget {
                       Expanded(
                         child: ListView.builder(
                           itemBuilder: (context, index) {
-                            // 現在地のソートオプションはアイコンでわかりやすく
+                            // 現在のソートオプションはアイコンでわかりやすく
                             final optionTile =
                                 optionList[index].label == sortOption.label
                                     ? Row(


### PR DESCRIPTION
### 変更内容

Closes #57 

 - RepoListのtotalCountProvider更新処理を除去
 - totalCountProviderでpageProviderをwatchし、更新

<details>

<summary>totalCountProvider</summary>

```dart
/// レポジトリ合計数プロバイダー

// pageProviderからの取得データによって更新
// 初回エラー、初回ローディング時はnullを返却
// ページング中エラー、ページング中ローディング時は前回値を返却
final totalCountProvider = StateProvider<int?>((ref) {
  final totalCount = ref.watch(pageProvider).whenOrNull(
        data: (data) => data.totalCount,
        // 前回値を渡す
        onGoingError: (previousData, e, stk) => previousData.totalCount,
        // 前回値を渡す
        onGoingLoading: (previousData) => previousData.totalCount,
      );

  return totalCount;
});
```


</details>