### PR TITLE
hasNextの更新ロジックを修正

### DIFF
--- a/lib/feature/github_repo/pagination/model/repo_pagination_state.dart
+++ b/lib/feature/github_repo/pagination/model/repo_pagination_state.dart
@@ -8,6 +8,7 @@ part 'repo_pagination_state.freezed.dart';
 @freezed
 class RepoPaginationState with _$RepoPaginationState {
   const factory RepoPaginationState({
+    @Default(true) bool hasNext,
     @Default(0) int totalCount,
     @Default(<GithubRepo>[]) List<GithubRepo> items,
     required RepoSearchRequestParam param,

--- a/lib/feature/github_repo/pagination/model/repo_pagination_state.freezed.dart
+++ b/lib/feature/github_repo/pagination/model/repo_pagination_state.freezed.dart
@@ -16,6 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$RepoPaginationState {
+  bool get hasNext => throw _privateConstructorUsedError;
   int get totalCount => throw _privateConstructorUsedError;
   List<GithubRepo> get items => throw _privateConstructorUsedError;
   RepoSearchRequestParam get param => throw _privateConstructorUsedError;
@@ -31,7 +32,10 @@ abstract class $RepoPaginationStateCopyWith<$Res> {
           RepoPaginationState value, $Res Function(RepoPaginationState) then) =
       _$RepoPaginationStateCopyWithImpl<$Res>;
   $Res call(
-      {int totalCount, List<GithubRepo> items, RepoSearchRequestParam param});
+      {bool hasNext,
+      int totalCount,
+      List<GithubRepo> items,
+      RepoSearchRequestParam param});
 
   $RepoSearchRequestParamCopyWith<$Res> get param;
 }
@@ -47,11 +51,16 @@ class _$RepoPaginationStateCopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? hasNext = freezed,
     Object? totalCount = freezed,
     Object? items = freezed,
     Object? param = freezed,
   }) {
     return _then(_value.copyWith(
+      hasNext: hasNext == freezed
+          ? _value.hasNext
+          : hasNext // ignore: cast_nullable_to_non_nullable
+              as bool,
       totalCount: totalCount == freezed
           ? _value.totalCount
           : totalCount // ignore: cast_nullable_to_non_nullable
@@ -83,7 +92,10 @@ abstract class _$$_RepoPaginationStateCopyWith<$Res>
       __$$_RepoPaginationStateCopyWithImpl<$Res>;
   @override
   $Res call(
-      {int totalCount, List<GithubRepo> items, RepoSearchRequestParam param});
+      {bool hasNext,
+      int totalCount,
+      List<GithubRepo> items,
+      RepoSearchRequestParam param});
 
   @override
   $RepoSearchRequestParamCopyWith<$Res> get param;
@@ -102,11 +114,16 @@ class __$$_RepoPaginationStateCopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? hasNext = freezed,
     Object? totalCount = freezed,
     Object? items = freezed,
     Object? param = freezed,
   }) {
     return _then(_$_RepoPaginationState(
+      hasNext: hasNext == freezed
+          ? _value.hasNext
+          : hasNext // ignore: cast_nullable_to_non_nullable
+              as bool,
       totalCount: totalCount == freezed
           ? _value.totalCount
           : totalCount // ignore: cast_nullable_to_non_nullable
@@ -127,11 +144,15 @@ class __$$_RepoPaginationStateCopyWithImpl<$Res>
 
 class _$_RepoPaginationState implements _RepoPaginationState {
   const _$_RepoPaginationState(
-      {this.totalCount = 0,
+      {this.hasNext = true,
+      this.totalCount = 0,
       final List<GithubRepo> items = const <GithubRepo>[],
       required this.param})
       : _items = items;
 
+  @override
+  @JsonKey()
+  final bool hasNext;
   @override
   @JsonKey()
   final int totalCount;
@@ -148,7 +169,7 @@ class _$_RepoPaginationState implements _RepoPaginationState {
 
   @override
   String toString() {
-    return 'RepoPaginationState(totalCount: $totalCount, items: $items, param: $param)';
+    return 'RepoPaginationState(hasNext: $hasNext, totalCount: $totalCount, items: $items, param: $param)';
   }
 
   @override
@@ -156,6 +177,7 @@ class _$_RepoPaginationState implements _RepoPaginationState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_RepoPaginationState &&
+            const DeepCollectionEquality().equals(other.hasNext, hasNext) &&
             const DeepCollectionEquality()
                 .equals(other.totalCount, totalCount) &&
             const DeepCollectionEquality().equals(other._items, _items) &&
@@ -165,6 +187,7 @@ class _$_RepoPaginationState implements _RepoPaginationState {
   @override
   int get hashCode => Object.hash(
       runtimeType,
+      const DeepCollectionEquality().hash(hasNext),
       const DeepCollectionEquality().hash(totalCount),
       const DeepCollectionEquality().hash(_items),
       const DeepCollectionEquality().hash(param));
@@ -178,10 +201,13 @@ class _$_RepoPaginationState implements _RepoPaginationState {
 
 abstract class _RepoPaginationState implements RepoPaginationState {
   const factory _RepoPaginationState(
-      {final int totalCount,
+      {final bool hasNext,
+      final int totalCount,
       final List<GithubRepo> items,
       required final RepoSearchRequestParam param}) = _$_RepoPaginationState;
 
+  @override
+  bool get hasNext;
   @override
   int get totalCount;
   @override

--- a/lib/feature/github_repo/pagination/pagination_notifier.dart
+++ b/lib/feature/github_repo/pagination/pagination_notifier.dart
@@ -59,9 +59,6 @@ class PaginationNotifier
   @override
   bool get mounted => super.mounted;
 
-  /// 追加のデータがあるかどうか
-  bool hasNext = true;
-
   /// [RepoSearchRequestParam]を用いてAPI通信
   final Future<RepoPaginationState> Function(RepoSearchRequestParam? param)
       fetchNextItems;
@@ -76,16 +73,13 @@ class PaginationNotifier
     }
     // 取得データをもとにrepoPaginationStateの更新
     repoPaginationState = repoPaginationState.copyWith(
+      hasNext:
+          result.totalCount > (repoPaginationState.items + result.items).length,
       totalCount: result.totalCount,
       items: repoPaginationState.items + result.items,
       param: result.param,
     );
     state = PaginationState.data(repoPaginationState);
-
-    // 次のデータがあるかチェック
-    if (repoPaginationState.items.length >= repoPaginationState.totalCount) {
-      hasNext = false;
-    }
   }
 
   /// 初回データの取得

--- a/lib/feature/github_repo/presentation/widgets/repo_list.dart
+++ b/lib/feature/github_repo/presentation/widgets/repo_list.dart
@@ -22,7 +22,7 @@ class RepoList extends ConsumerWidget {
               : RepoListBuilder(
                   repos: data.items,
                   onLoading: pagingController.fetchNextBatch,
-                  hasNext: pagingController.hasNext,
+                  hasNext: data.hasNext,
                 );
         },
         loading: () => const Center(


### PR DESCRIPTION
Closes #62 

PaginationNotifierからhasNextを除去し、RepoPaginationStateで完結するようにした。

API通信のデータ取得とページング可否は同期することができた。